### PR TITLE
chore: Add semantic commit types to renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":semanticCommits"
   ]
 }


### PR DESCRIPTION
- PRs open by renovate were failing CI due to `conventional commit` failures
- Fixing this by adding `:semanticCommits` to renovate.json