### PR TITLE
fix: version pin terraform-google-vm module to ~> 6.3.0

### DIFF
--- a/anthos-bm-gcp-terraform/modules/vm/main.tf
+++ b/anthos-bm-gcp-terraform/modules/vm/main.tf
@@ -21,6 +21,7 @@ module "external_ip_addresses" {
 
 module "compute_instance" {
   source            = "terraform-google-modules/vm/google//modules/compute_instance"
+  version           = "~> 6.3.0"
   instance_template = var.instance_template
   region            = var.region
   for_each          = toset(var.vm_names)


### PR DESCRIPTION
### Issue
- Latest release of [terraform-google-vm](https://github.com/terraform-google-modules/terraform-google-vm/releases) breaks the vm module due to the `instance_details` output being `sensitive`

### Fix
- Pin the version for the  [terraform-google-vm](https://github.com/terraform-google-modules/terraform-google-vm) module to `~> 6.3.0` so that on patch versions on 6.3 are included