### PR TITLE
feat: add monitoring dashboard for multicloud/aws

### DIFF
--- a/aws-logging-monitoring/README.md
+++ b/aws-logging-monitoring/README.md
@@ -3,3 +3,5 @@
 This directory contains Kubernetes manifests to export logs and metrics from an
 [Anthos clusters on AWS](https://cloud.google.com/anthos/gke/docs/aws/how-to#installing-anthos-gke-on-aws)
 to Cloud Operations (Stackdriver).
+
+To use the samples in this directory, users are expected to follow [Instruction on Configuring logging and monitoring for Anthos clusters on AWS](https://cloud.google.com/anthos/clusters/docs/aws/how-to/logging-and-monitoring).

--- a/aws-logging-monitoring/monitoring/dashboards/pod-status.json
+++ b/aws-logging-monitoring/monitoring/dashboards/pod-status.json
@@ -1,0 +1,137 @@
+{
+  "displayName": "CLUSTER_NAME (Anthos cluster on AWS) pod status",
+  "gridLayout": {
+    "columns": 2,
+    "widgets": [
+      {
+        "title": "Memory usage per container",
+        "xyChart": {
+          "dataSets": [
+            {
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"kubernetes.io/anthos/container_memory_working_set_bytes\" resource.label.\"cluster_name\"=\"CLUSTER_NAME\" resource.type=\"k8s_node\" metric.label.\"container\"!=\"POD\" metric.label.\"container\"=monitoring.regex.full_match(\".*.*\")",
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_MEAN",
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "groupByFields": [
+                      "metric.label.\"container\""
+                    ]
+                  }
+                },
+                "unitOverride": "1"
+              },
+              "plotType": "LINE",
+              "minAlignmentPeriod": "60s"
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          },
+          "chartOptions": {
+            "mode": "COLOR"
+          }
+        }
+      },
+      {
+        "title": "CPU usage per container",
+        "xyChart": {
+          "dataSets": [
+            {
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"kubernetes.io/anthos/container_cpu_usage_seconds_total\" resource.label.\"cluster_name\"=\"CLUSTER_NAME\" resource.type=\"k8s_node\" metric.label.\"container\"!=\"POD\" metric.label.\"container\"=monitoring.regex.full_match(\".*.*\")",
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_RATE",
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "groupByFields": [
+                      "metric.label.\"container\""
+                    ]
+                  }
+                },
+                "unitOverride": "1"
+              },
+              "plotType": "LINE",
+              "minAlignmentPeriod": "60s"
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          },
+          "chartOptions": {
+            "mode": "COLOR"
+          }
+        }
+      },
+      {
+        "title": "Network ingress (bytes) per pod",
+        "xyChart": {
+          "dataSets": [
+            {
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"kubernetes.io/anthos/container_network_receive_bytes_total\" resource.label.\"cluster_name\"=\"CLUSTER_NAME\" resource.type=\"k8s_node\" metric.label.\"pod\"=monitoring.regex.full_match(\".*.*\")",
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_RATE",
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "groupByFields": [
+                      "metric.label.\"pod\""
+                    ]
+                  }
+                },
+                "unitOverride": "1"
+              },
+              "plotType": "LINE",
+              "minAlignmentPeriod": "60s"
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          },
+          "chartOptions": {
+            "mode": "COLOR"
+          }
+        }
+      },
+      {
+        "title": "Network egress (bytes) per pod",
+        "xyChart": {
+          "dataSets": [
+            {
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"kubernetes.io/anthos/container_network_transmit_bytes_total\" resource.label.\"cluster_name\"=\"CLUSTER_NAME\" resource.type=\"k8s_node\" metric.label.\"pod\"=monitoring.regex.full_match(\".*.*\")",
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_RATE",
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "groupByFields": [
+                      "metric.label.\"pod\""
+                    ]
+                  }
+                },
+                "unitOverride": "1"
+              },
+              "plotType": "LINE",
+              "minAlignmentPeriod": "60s"
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          },
+          "chartOptions": {
+            "mode": "COLOR"
+          }
+        }
+      }
+    ]
+  }
+}
+


### PR DESCRIPTION
Provide sample cloud monitoring dashboard config file to monitor container status in Anthos on AWS clusters.

Sample config file based from Anthos on-prem(VMware) monitoring dashboard [instructions](https://cloud.google.com/anthos/clusters/docs/on-prem/how-to/logging-and-monitoring#dashboards).