### PR TITLE
process: Add new Github runner in the anthos-gke-samples-ci project

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,26 @@
+## Creating a new Actions runner
+
+The actions runners for this repository are hosted in the `anthos-gke-samples-ci` project. If you want to add new runners _(for capacity purposes or upgrading tools installed in the runners)_ you can follow the guidelines below:
+
+- Runners are created in the `anthos-gke-samples-ci` project in GCP
+- The runner VMs should:
+  - be at least n1-standard-4
+  - have atleast 50GB persistent disk
+  - use custom service account with only `read` permissions to the `Compute Engine API`
+
+- Once the VM for the runner is created
+  - SSH into new VM through Google Cloud Console
+  - Follow the instructions to add a new runner by clicking `Add runner` in the [Actions settings](https://github.com/GoogleCloudPlatform/anthos-samples/settings/actions/runners) page
+  - Add a label of the form `runner-<month>-<year>` _(e.g: runner-july-21)_ to te newly created runner _(you can do this whilst following the setup guide from inside the VM or do it in the [runners](https://github.com/GoogleCloudPlatform/anthos-samples/settings/actions/runners) page after you have authenticated the VM)_
+  - Start GitHub Actions as a background service:
+  ```
+  sudo ~/actions-runner/svc.sh install ; sudo ~/actions-runner/svc.sh start
+  ```
+  - Install repository-specific dependencies using the [gh_runner_dependencies.sh](./gh_runner_dependencies.sh) file:
+  ```
+  wget -O - https://raw.githubusercontent.com/GoogleCloudPlatform/anthos-samples/master/.github/workflows/gh_runner_dependencies.sh | bash
+  ```
+- Finally open a PR with the following changes:
+  - Update the [workflow files](./workflows) to use the new runner label _(e.g: runner-jan-2031 as used above)_ for the `runs-on` directive for Github actions
+- Verify that the actions run on the new runner without any issues
+

--- a/.github/gh_runner_dependencies.sh
+++ b/.github/gh_runner_dependencies.sh
@@ -35,8 +35,19 @@ tfenv install 0.14.9
 tfenv install 0.15.5
 tfenv install 1.0.0
 tfenv install 1.0.1
-
 tfenv use 0.14.9
 
 go get -u golang.org/x/lint/golint
 sudo ln -s "$HOME"/go/bin/golint /bin/
+
+sudo mkdir -p /var/local/gh-runner
+echo "All dependencies have been installed."
+echo "You have to download the Service Account key into this host, store it under /var/local/gh-runner and give it 444 permissions"
+echo "
+  > gcloud auth login
+  > PROJECT_ID=anthos-gke-samples-ci
+  > SERVICE_ACCOUNT_NAME=gh-actions-anthos-samples-sa
+  > gcloud iam service-accounts keys create sa-key.json --iam-account=${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com
+  > sudo mv ./sa-key.json /var/local/gh-runner/
+  > sudo chmod 444 /var/local/gh-runner/sa-key.json
+"

--- a/.github/gh_runner_dependencies.sh
+++ b/.github/gh_runner_dependencies.sh
@@ -21,15 +21,15 @@ wget "https://dl.google.com/go/$(curl https://golang.org/VERSION?m=text).linux-a
 sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go*
 sudo chown -R root:root ./go
 sudo mv go /usr/local
-echo 'export GOPATH=$HOME/go' >> ~/.profile
-echo 'export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin' >> ~/.profile
-source ~/.profile
+echo "export GOPATH=$HOME/go" >> $HOME/.profile
+echo "export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin" >> $HOME/.profile
+source $HOME/.profile
 
 go get -u github.com/google/addlicense
 sudo ln -s $HOME/go/bin/addlicense /bin
 
 git clone https://github.com/tfutils/tfenv.git ~/.tfenv
-sudo ln -s ~/.tfenv/bin/* /bin
+sudo ln -s $HOME/.tfenv/bin/* /bin
 
 tfenv install 0.14.9
 tfenv install 0.15.5
@@ -39,4 +39,4 @@ tfenv install 1.0.1
 tfenv use 0.14.9
 
 go get -u golang.org/x/lint/golint
-sudo ln -s go/bin/golint /bin/
+sudo ln -s $HOME/go/bin/golint /bin/

--- a/.github/gh_runner_dependencies.sh
+++ b/.github/gh_runner_dependencies.sh
@@ -14,22 +14,22 @@
 # limitations under the License.
 
 
-cd $HOME
-sudo apt-get install -y curl wget vim git unzip
+cd "$HOME"
+sudo apt-get install -y curl wget vim git unzip gcc
 
 wget "https://dl.google.com/go/$(curl https://golang.org/VERSION?m=text).linux-amd64.tar.gz"
 sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go*
 sudo chown -R root:root ./go
 sudo mv go /usr/local
 echo "export GOPATH=$HOME/go" >> $HOME/.profile
-echo "export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin" >> $HOME/.profile
-source $HOME/.profile
+echo "export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin" >> "$HOME"/.profile
+source "$HOME"/.profile
 
 go get -u github.com/google/addlicense
-sudo ln -s $HOME/go/bin/addlicense /bin
+sudo ln -s "$HOME"/go/bin/addlicense /bin
 
 git clone https://github.com/tfutils/tfenv.git ~/.tfenv
-sudo ln -s $HOME/.tfenv/bin/* /bin
+sudo ln -s "$HOME"/.tfenv/bin/* /bin
 
 tfenv install 0.14.9
 tfenv install 0.15.5
@@ -39,4 +39,4 @@ tfenv install 1.0.1
 tfenv use 0.14.9
 
 go get -u golang.org/x/lint/golint
-sudo ln -s $HOME/go/bin/golint /bin/
+sudo ln -s "$HOME"/go/bin/golint /bin/

--- a/.github/gh_runner_dependencies.sh
+++ b/.github/gh_runner_dependencies.sh
@@ -23,7 +23,7 @@ sudo chown -R root:root ./go
 sudo mv go /usr/local
 echo "export GOPATH=$HOME/go" >> "$HOME"/.profile
 echo "export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin" >> "$HOME"/.profile
-. "$HOME"/.profile
+. ~/.profile
 
 go get -u github.com/google/addlicense
 sudo ln -s "$HOME"/go/bin/addlicense /bin

--- a/.github/gh_runner_dependencies.sh
+++ b/.github/gh_runner_dependencies.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+cd $HOME
+sudo apt-get install -y curl wget vim git unzip
+
+wget "https://dl.google.com/go/$(curl https://golang.org/VERSION?m=text).linux-amd64.tar.gz"
+sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go*
+sudo chown -R root:root ./go
+sudo mv go /usr/local
+echo 'export GOPATH=$HOME/go' >> ~/.profile
+echo 'export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin' >> ~/.profile
+source ~/.profile
+
+go get -u github.com/google/addlicense
+sudo ln -s $HOME/go/bin/addlicense /bin
+
+sudo git clone https://github.com/tfutils/tfenv.git /root/.tfenv
+sudo ln -s /root/.tfenv/bin/tfenv /bin
+
+tfenv install 0.14.9
+tfenv install 0.15.5
+tfenv install 1.0.0
+
+tfenv use 0.14.9

--- a/.github/gh_runner_dependencies.sh
+++ b/.github/gh_runner_dependencies.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 cd $HOME
 sudo apt-get install -y curl wget vim git unzip

--- a/.github/gh_runner_dependencies.sh
+++ b/.github/gh_runner_dependencies.sh
@@ -23,7 +23,8 @@ sudo chown -R root:root ./go
 sudo mv go /usr/local
 echo "export GOPATH=$HOME/go" >> "$HOME"/.profile
 echo "export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin" >> "$HOME"/.profile
-. ~/.profile
+# shellcheck source="$HOME"/.profile
+. "$HOME"/.profile
 
 go get -u github.com/google/addlicense
 sudo ln -s "$HOME"/go/bin/addlicense /bin

--- a/.github/gh_runner_dependencies.sh
+++ b/.github/gh_runner_dependencies.sh
@@ -14,16 +14,16 @@
 # limitations under the License.
 
 
-cd "$HOME"
+cd "$HOME" || exit
 sudo apt-get install -y curl wget vim git unzip gcc
 
 wget "https://dl.google.com/go/$(curl https://golang.org/VERSION?m=text).linux-amd64.tar.gz"
 sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go*
 sudo chown -R root:root ./go
 sudo mv go /usr/local
-echo "export GOPATH=$HOME/go" >> $HOME/.profile
+echo "export GOPATH=$HOME/go" >> "$HOME"/.profile
 echo "export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin" >> "$HOME"/.profile
-source "$HOME"/.profile
+. "$HOME"/.profile
 
 go get -u github.com/google/addlicense
 sudo ln -s "$HOME"/go/bin/addlicense /bin

--- a/.github/gh_runner_dependencies.sh
+++ b/.github/gh_runner_dependencies.sh
@@ -23,8 +23,8 @@ sudo chown -R root:root ./go
 sudo mv go /usr/local
 echo "export GOPATH=$HOME/go" >> "$HOME"/.profile
 echo "export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin" >> "$HOME"/.profile
-# shellcheck source="$HOME"/.profile
-. "$HOME"/.profile
+# shellcheck source=~/.profile
+source ~/.profile
 
 go get -u github.com/google/addlicense
 sudo ln -s "$HOME"/go/bin/addlicense /bin

--- a/.github/gh_runner_dependencies.sh
+++ b/.github/gh_runner_dependencies.sh
@@ -28,11 +28,15 @@ source ~/.profile
 go get -u github.com/google/addlicense
 sudo ln -s $HOME/go/bin/addlicense /bin
 
-sudo git clone https://github.com/tfutils/tfenv.git /root/.tfenv
-sudo ln -s /root/.tfenv/bin/tfenv /bin
+git clone https://github.com/tfutils/tfenv.git ~/.tfenv
+sudo ln -s ~/.tfenv/bin/* /bin
 
 tfenv install 0.14.9
 tfenv install 0.15.5
 tfenv install 1.0.0
+tfenv install 1.0.1
 
 tfenv use 0.14.9
+
+go get -u golang.org/x/lint/golint
+sudo ln -s go/bin/golint /bin/

--- a/.github/gh_runner_dependencies.sh
+++ b/.github/gh_runner_dependencies.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+# shellcheck disable=SC1090
 cd "$HOME" || exit
 sudo apt-get install -y curl wget vim git unzip gcc
 
@@ -23,8 +23,7 @@ sudo chown -R root:root ./go
 sudo mv go /usr/local
 echo "export GOPATH=$HOME/go" >> "$HOME"/.profile
 echo "export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin" >> "$HOME"/.profile
-# shellcheck source=~/.profile
-source ~/.profile
+source "$HOME"/.profile
 
 go get -u github.com/google/addlicense
 sudo ln -s "$HOME"/go/bin/addlicense /bin

--- a/.github/workflows/ci_any_pr.yaml
+++ b/.github/workflows/ci_any_pr.yaml
@@ -20,7 +20,7 @@ on:
       - master
 jobs:
   static-code-tests:
-    runs-on: [self-hosted, runner-july-21]
+    runs-on: [self-hosted, runner-july-21, runner2]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -47,7 +47,7 @@ jobs:
             exit 1
           fi
   tf-validate:
-    runs-on: [self-hosted, runner-july-21]
+    runs-on: [self-hosted, runner-july-21, runner2]
     strategy:
       matrix:
         # list of directories in the repo that hosts Terraform samples
@@ -71,7 +71,7 @@ jobs:
           terraform init -backend=false
           terraform validate -json .
   go-unit-tests:
-    runs-on: [self-hosted, runner-july-21]
+    runs-on: [self-hosted, runner-july-21, runner2]
     needs: tf-validate
     strategy:
       matrix:

--- a/.github/workflows/ci_any_pr.yaml
+++ b/.github/workflows/ci_any_pr.yaml
@@ -32,6 +32,7 @@ jobs:
       - name: Terraform Checkstyle
         timeout-minutes: 20
         run: |
+          tfenv use 0.14.9
           terraform fmt -recursive -check -diff ./
       - name: Golang Checkstyle
         timeout-minutes: 20

--- a/.github/workflows/ci_any_pr.yaml
+++ b/.github/workflows/ci_any_pr.yaml
@@ -20,7 +20,7 @@ on:
       - master
 jobs:
   static-code-tests:
-    runs-on: [self-hosted, runner-july-21, runner2]
+    runs-on: [self-hosted, runner-july-21]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -47,7 +47,7 @@ jobs:
             exit 1
           fi
   tf-validate:
-    runs-on: [self-hosted, runner-july-21, runner2]
+    runs-on: [self-hosted, runner-july-21]
     strategy:
       matrix:
         # list of directories in the repo that hosts Terraform samples
@@ -71,7 +71,7 @@ jobs:
           terraform init -backend=false
           terraform validate -json .
   go-unit-tests:
-    runs-on: [self-hosted, runner-july-21, runner2]
+    runs-on: [self-hosted, runner-july-21]
     needs: tf-validate
     strategy:
       matrix:

--- a/.github/workflows/ci_any_pr.yaml
+++ b/.github/workflows/ci_any_pr.yaml
@@ -20,7 +20,7 @@ on:
       - master
 jobs:
   static-code-tests:
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, runner-july-21]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -46,7 +46,7 @@ jobs:
             exit 1
           fi
   tf-validate:
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, runner-july-21]
     strategy:
       matrix:
         # list of directories in the repo that hosts Terraform samples
@@ -69,7 +69,7 @@ jobs:
           terraform init -backend=false
           terraform validate -json .
   go-unit-tests:
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, runner-july-21]
     needs: tf-validate
     strategy:
       matrix:

--- a/.github/workflows/ci_any_pr.yaml
+++ b/.github/workflows/ci_any_pr.yaml
@@ -67,6 +67,7 @@ jobs:
         run: |
           echo "Terraform validating: $SAMPLE_DIR"
           cd $SAMPLE_DIR
+          tfenv use 0.14.9
           terraform init -backend=false
           terraform validate -json .
   go-unit-tests:

--- a/.github/workflows/ci_master_branch.yaml
+++ b/.github/workflows/ci_master_branch.yaml
@@ -34,6 +34,7 @@ jobs:
       - name: Terraform Checkstyle
         timeout-minutes: 20
         run: |
+          tfenv use 0.14.9
           terraform fmt -recursive -check -diff ./
       - name: Golang Checkstyle
         timeout-minutes: 20
@@ -68,6 +69,7 @@ jobs:
         run: |
           echo "Terraform validating: $SAMPLE_DIR"
           cd $SAMPLE_DIR
+          tfenv use 0.14.9
           terraform init -backend=false
           terraform validate -json .
   go-unit-tests:

--- a/.github/workflows/ci_master_branch.yaml
+++ b/.github/workflows/ci_master_branch.yaml
@@ -22,7 +22,7 @@ on:
       - release/*
 jobs:
   static-code-tests:
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, runner-july-21]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -48,7 +48,7 @@ jobs:
             exit 1
           fi
   tf-validate:
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, runner-july-21]
     strategy:
       matrix:
         # list of directories in the repo that hosts Terraform samples
@@ -71,7 +71,7 @@ jobs:
           terraform init -backend=false
           terraform validate -json .
   go-unit-tests:
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, runner-july-21]
     needs: tf-validate
     strategy:
       matrix:


### PR DESCRIPTION
### Fixes 
- Github actions runner was in a personal project under `runcible.org`

#### Description
- The Github actions runners for all the Anthos/GKE samples should ideally be one project

#### Change summary
- Added new runner in the `anthos-gke-samples-ci` project and configured this PR to start running on it


