### PR TITLE
fix: bash trap signal error on gce-tf sample initialization script

### DIFF
--- a/anthos-bm-gcp-terraform/resources/run_initialization_checks.sh
+++ b/anthos-bm-gcp-terraform/resources/run_initialization_checks.sh
@@ -90,7 +90,7 @@ function __cleanup__ () {
 function __trap_with_arg__ () {
   FUNC="$1" ; shift
   for SIG ; do
-    trap '$FUNC $SIG' '$SIG'
+    trap "$FUNC $SIG" "$SIG"
   done
 }
 

--- a/anthos-bm-gcp-terraform/resources/run_initialization_checks.sh
+++ b/anthos-bm-gcp-terraform/resources/run_initialization_checks.sh
@@ -90,6 +90,7 @@ function __cleanup__ () {
 function __trap_with_arg__ () {
   FUNC="$1" ; shift
   for SIG ; do
+    # shellcheck disable=SC2064
     trap "$FUNC $SIG" "$SIG"
   done
 }


### PR DESCRIPTION
### Fixes #65 
- The issue was with bash expansion with single quoted variables

#### Description
- The issue could be fixed by replacing the single quotes with double quotes

#### Change summary
- Add double quotes instead of single quotes