### PR TITLE
feat: add oslogin metadata to override project wide setting

### DIFF
--- a/anthos-bm-gcp-terraform/main.tf
+++ b/anthos-bm-gcp-terraform/main.tf
@@ -112,6 +112,7 @@ module "instance_template" {
   tags                 = var.tags             # --tags http-server,https-server
   min_cpu_platform     = var.min_cpu_platform # --min-cpu-platform "Intel Haswell"
   can_ip_forward       = true                 # --can-ip-forward
+  # Disable oslogin explicitly since we rely on metadata based ssh-key (issues/70). 
   metadata = {
     enable-oslogin = "false"
   }

--- a/anthos-bm-gcp-terraform/main.tf
+++ b/anthos-bm-gcp-terraform/main.tf
@@ -112,7 +112,7 @@ module "instance_template" {
   tags                 = var.tags             # --tags http-server,https-server
   min_cpu_platform     = var.min_cpu_platform # --min-cpu-platform "Intel Haswell"
   can_ip_forward       = true                 # --can-ip-forward
-  # Disable oslogin explicitly since we rely on metadata based ssh-key (issues/70). 
+  # Disable oslogin explicitly since we rely on metadata based ssh-key (issues/70).
   metadata = {
     enable-oslogin = "false"
   }

--- a/anthos-bm-gcp-terraform/main.tf
+++ b/anthos-bm-gcp-terraform/main.tf
@@ -112,6 +112,9 @@ module "instance_template" {
   tags                 = var.tags             # --tags http-server,https-server
   min_cpu_platform     = var.min_cpu_platform # --min-cpu-platform "Intel Haswell"
   can_ip_forward       = true                 # --can-ip-forward
+  metadata = {
+    enable-oslogin = "false"
+  }
   service_account = {
     email  = ""
     scopes = var.access_scopes # --scopes cloud-platform


### PR DESCRIPTION
### Fixes #70
- #70

#### Description
- The terraform apply fails when project wide oslogin is enabled with ssh error.

#### Change summary
- Add oslogin metadata to instance template to override project wide setting

#### Related PRs/Issues


