### PR TITLE
release: update bmctl version to 1.8.0

### DIFF
--- a/anthos-bm-gcp-terraform/resources/anthos_gce_cluster.tpl
+++ b/anthos-bm-gcp-terraform/resources/anthos_gce_cluster.tpl
@@ -17,7 +17,7 @@ metadata:
   namespace: ${clusterId}-ns
 spec:
   type: hybrid
-  anthosBareMetalVersion: 1.7.0
+  anthosBareMetalVersion: 1.8.0
   gkeConnect:
     projectID: ${projectId}
   controlPlane:

--- a/anthos-bm-gcp-terraform/resources/init.sh
+++ b/anthos-bm-gcp-terraform/resources/init.sh
@@ -177,7 +177,7 @@ function __setup_kubctl__ () {
 ##############################################################################
 function __setup_bmctl__ () {
   mkdir baremetal && cd baremetal || return
-  gsutil cp gs://anthos-baremetal-release/bmctl/1.7.0/linux-amd64/bmctl .
+  gsutil cp gs://anthos-baremetal-release/bmctl/1.8.0/linux-amd64/bmctl .
   chmod a+x bmctl
   mv bmctl /usr/local/sbin/
   __check_exit_status__ $? \

--- a/test/integration/abm_gce_defaults_on_editor_project/controls/gcloud.rb
+++ b/test/integration/abm_gce_defaults_on_editor_project/controls/gcloud.rb
@@ -96,8 +96,8 @@ control "gcloud" do
       end
     end
     describe "bmctl version" do
-      it "should be 1.7.x" do
-        expect(data).to include("bmctl version: 1.7")
+      it "should be 1.8.x" do
+        expect(data).to include("bmctl version: 1.8")
       end
     end
   end

--- a/test/integration/abm_gce_defaults_on_owner_project/controls/gcloud.rb
+++ b/test/integration/abm_gce_defaults_on_owner_project/controls/gcloud.rb
@@ -97,8 +97,8 @@ control "gcloud" do
       end
     end
     describe "bmctl version" do
-      it "should be 1.7.x" do
-        expect(data).to include("bmctl version: 1.7")
+      it "should be 1.8.x" do
+        expect(data).to include("bmctl version: 1.8")
       end
     end
   end


### PR DESCRIPTION
### Fixes https://github.com/GoogleCloudPlatform/anthos-samples/issues/86

#### Description
- `bmctl` version needs to be updated to latest minor version

#### Change summary
- Update `bmctl` CLI version in the initialization script
- Update the `bmctl` version in the `cluster.yaml` configuration
- Update the `bmctl` version in the integrationtests

#### Related PRs/Issues
- #69 


