### PR TITLE
feat: enable support to toggle oslogin on vm

### DIFF
--- a/anthos-bm-gcp-terraform/main.tf
+++ b/anthos-bm-gcp-terraform/main.tf
@@ -116,6 +116,9 @@ module "instance_template" {
     email  = ""
     scopes = var.access_scopes # --scopes cloud-platform
   }
+  metadata = {
+    enable-oslogin = var.oslogin
+  }
   gpu = !local.gpu_enabled ? null : {
     type  = var.gpu.type
     count = var.gpu.count

--- a/anthos-bm-gcp-terraform/test/unit/main_test.go
+++ b/anthos-bm-gcp-terraform/test/unit/main_test.go
@@ -62,6 +62,7 @@ func TestUnit_MainScript(goTester *testing.T) {
 	imageFamily := "test_image_family"
 	bootDiskType := "test_boot_disk_type"
 	abmClusterID := "test_abm_cluster_id"
+	oslogin := "true"
 	network := "test_network"
 	bootDiskSize := 175
 	anthosServiceAccountName := gcp.RandomValidGcpName()
@@ -114,6 +115,7 @@ func TestUnit_MainScript(goTester *testing.T) {
 		"primary_apis":                primaryApis,
 		"secondary_apis":              secondaryApis,
 		"abm_cluster_id":              abmClusterID,
+		"oslogin":                     oslogin,
 		"instance_count":              instanceCount,
 		"gpu":                         gpu,
 	}
@@ -371,6 +373,14 @@ func TestUnit_MainScript_ValidateDefaults(goTester *testing.T) {
 		"anthos-gce-cluster",
 		terraformPlan.Variables.ABMClusterID.Value,
 		"Variable does not match expected default value: abm_cluster_id.",
+	)
+
+	// verify input variable oslogin in plan matches the default value
+	assert.Equal(
+		goTester,
+		"false",
+		terraformPlan.Variables.OSLogin.Value,
+		"Variable does not match expected default value: oslogin.",
 	)
 
 	defaultTags := []string{"http-server", "https-server"}
@@ -716,6 +726,13 @@ func validateVariablesInMain(goTester *testing.T, tfPlan *util.MainModulePlan) {
 		"Variable not found in plan: abm_cluster_id",
 	)
 
+	// verify plan has oslogin input variable
+	assert.NotNil(
+		goTester,
+		tfPlan.Variables.OSLogin,
+		"Variable not found in plan: oslogin",
+	)
+
 	// verify plan has anthos_service_account_name input variable
 	assert.NotNil(
 		goTester,
@@ -884,6 +901,14 @@ func validateVariableValuesInMain(goTester *testing.T, tfPlan *util.MainModulePl
 		(*vars)["abm_cluster_id"],
 		tfPlan.Variables.ABMClusterID.Value,
 		"Variable does not match in plan: abm_cluster_id.",
+	)
+
+	// verify input variable oslogin in plan matches
+	assert.Equal(
+		goTester,
+		(*vars)["oslogin"],
+		tfPlan.Variables.OSLogin.Value,
+		"Variable does not match in plan: oslogin.",
 	)
 
 	// verify input variable anthos_service_account_name in plan matches

--- a/anthos-bm-gcp-terraform/test/util/module_main.go
+++ b/anthos-bm-gcp-terraform/test/util/module_main.go
@@ -46,6 +46,7 @@ type MainVariables struct {
 	ImageProject             *Variable     `json:"image_project"`
 	MachineType              *Variable     `json:"machine_type"`
 	MinCPUPlatform           *Variable     `json:"min_cpu_platform"`
+	OSLogin                  *Variable     `json:"oslogin"`
 	Tags                     *ListVariable `json:"tags"`
 	AccessScope              *ListVariable `json:"access_scopes"`
 	PrimaryAPIs              *ListVariable `json:"primary_apis"`

--- a/anthos-bm-gcp-terraform/variables.tf
+++ b/anthos-bm-gcp-terraform/variables.tf
@@ -163,6 +163,12 @@ variable "abm_cluster_id" {
   default     = "anthos-gce-cluster"
 }
 
+variable "oslogin" {
+  description = "Indicate whether to enable oslogin for the VM instance"
+  type        = string
+  default     = "false"
+}
+
 # [START anthos_bm_node_prefix]
 ###################################################################################
 # The recommended instance count for High Availability (HA) is 3 for Control plane


### PR DESCRIPTION
### Fixes #70

#### Description
- Need to give support to toggle [oslogin](https://cloud.google.com/compute/docs/instances/managing-instance-access) capability on the VM instance

#### Change summary
- Add a new variable called `oslogin`to toggle oslogin on VMs
- Update tests to accommodate the new variable

#### Related PRs/Issues
- #71 


