### PR TITLE
chore: bump devtools version, relax module version constraint

### DIFF
--- a/.github/gh_runner_dependencies.sh
+++ b/.github/gh_runner_dependencies.sh
@@ -35,6 +35,7 @@ tfenv install 0.14.9
 tfenv install 0.15.5
 tfenv install 1.0.0
 tfenv install 1.0.1
+tfenv install 1.0.6
 tfenv use 0.14.9
 
 go get -u golang.org/x/lint/golint

--- a/.github/workflows/ci_any_pr.yaml
+++ b/.github/workflows/ci_any_pr.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Terraform Checkstyle
         timeout-minutes: 20
         run: |
-          tfenv use 0.15.5
+          tfenv use 1.0.6
           terraform fmt -recursive -check -diff ./
       - name: Golang Checkstyle
         timeout-minutes: 20
@@ -67,7 +67,7 @@ jobs:
         run: |
           echo "Terraform validating: $SAMPLE_DIR"
           cd $SAMPLE_DIR
-          tfenv use 0.15.5
+          tfenv use 1.0.6
           terraform init -backend=false
           terraform validate -json .
   go-unit-tests:

--- a/.github/workflows/ci_master_branch.yaml
+++ b/.github/workflows/ci_master_branch.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Terraform Checkstyle
         timeout-minutes: 20
         run: |
-          tfenv use 0.15.5
+          tfenv use 1.0.6
           terraform fmt -recursive -check -diff ./
       - name: Golang Checkstyle
         timeout-minutes: 20
@@ -69,7 +69,7 @@ jobs:
         run: |
           echo "Terraform validating: $SAMPLE_DIR"
           cd $SAMPLE_DIR
-          tfenv use 0.15.5
+          tfenv use 1.0.6
           terraform init -backend=false
           terraform validate -json .
   go-unit-tests:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHELL := /usr/bin/env bash
 
 # release images are available at:
 # console.google.com/gcr/images/cloud-foundation-cicd/global/cft/developer-tools?project=cloud-foundation-cicd
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.15.9
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.1
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/anthos-bm-gcp-terraform/README.md
+++ b/anthos-bm-gcp-terraform/README.md
@@ -8,7 +8,7 @@ This repository shows you how to use Terraform to try Anthos clusters on bare me
 - A workstation with access to internet _(i.e. Google Cloud APIs)_ with the following installed
   - [Git](https://www.atlassian.com/git/tutorials/install-git)
   - [Google Cloud SDK](https://cloud.google.com/sdk/docs/install)
-  - [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) (>= v0.15.5)
+  - [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) (>= v0.15.5, < v1.1)
 
 - A [Google Cloud Project](https://console.cloud.google.com/cloud-resource-manager?_ga=2.187862184.1029435410.1614837439-1338907320.1614299892) _(in which the resources for the setup will be provisioned)_
 

--- a/anthos-bm-gcp-terraform/README.md
+++ b/anthos-bm-gcp-terraform/README.md
@@ -8,7 +8,7 @@ This repository shows you how to use Terraform to try Anthos clusters on bare me
 - A workstation with access to internet _(i.e. Google Cloud APIs)_ with the following installed
   - [Git](https://www.atlassian.com/git/tutorials/install-git)
   - [Google Cloud SDK](https://cloud.google.com/sdk/docs/install)
-  - [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) (~v0.15.5)
+  - [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) (>= v0.15.5)
 
 - A [Google Cloud Project](https://console.cloud.google.com/cloud-resource-manager?_ga=2.187862184.1029435410.1614837439-1338907320.1614299892) _(in which the resources for the setup will be provisioned)_
 

--- a/anthos-bm-gcp-terraform/versions.tf
+++ b/anthos-bm-gcp-terraform/versions.tf
@@ -25,7 +25,7 @@ terraform {
     gcp_service_accounts  = "terraform-google-modules/service-accounts/google/v~> 4.0"
     gcp_compute_instances = "terraform-google-modules/vm/google//modules/compute_instance/v~> 6.3.0"
   }
-  required_version = ">= 0.15.5"
+  required_version = "~> 0.15.5, ~> 1.0.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/anthos-bm-gcp-terraform/versions.tf
+++ b/anthos-bm-gcp-terraform/versions.tf
@@ -25,7 +25,7 @@ terraform {
     gcp_service_accounts  = "terraform-google-modules/service-accounts/google/v~> 4.0"
     gcp_compute_instances = "terraform-google-modules/vm/google//modules/compute_instance/v~> 6.3.0"
   }
-  required_version = "~> 0.15.5, ~> 1.0.0"
+  required_version = ">= 0.15.5, < 1.1"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/anthos-bm-gcp-terraform/versions.tf
+++ b/anthos-bm-gcp-terraform/versions.tf
@@ -25,7 +25,7 @@ terraform {
     gcp_service_accounts  = "terraform-google-modules/service-accounts/google/v~> 4.0"
     gcp_compute_instances = "terraform-google-modules/vm/google//modules/compute_instance/v~> 6.3.0"
   }
-  required_version = "~> 0.15.5"
+  required_version = ">= 0.15.5"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -86,6 +86,6 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.15.9'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.1'
 options:
   machineType: 'N1_HIGHCPU_8'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -22,7 +22,7 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.15.9'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.1'
 options:
   machineType: 'N1_HIGHCPU_8'
   env:

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.15.5"
+  required_version = ">= 0.15.5"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.15.5"
+  required_version = "~> 0.15.5, ~> 1.0.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.15.5, ~> 1.0.0"
+  required_version = ">= 0.15.5, < 1.1"
   required_providers {
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
#### Fixes https://github.com/GoogleCloudPlatform/anthos-samples/pull/48

#### Change summary
- bump devtools version
- relax module version constraint to support TF 1.0+



