### PR TITLE
feat: application metrics for multicloud/aws klite

### DIFF
--- a/aws-logging-monitoring/monitoring/gke-metrics-agent.yaml
+++ b/aws-logging-monitoring/monitoring/gke-metrics-agent.yaml
@@ -150,6 +150,51 @@ metadata:
 data:
   config.yaml: |+
     exporters:
+      stackdriver/app-metrics:
+        endpoint: monitoring.googleapis.com:443
+        metric:
+          prefix: external.googleapis.com/prometheus
+          skip_create_descriptor: false
+        resource_mappings:
+        - label_mappings:
+          - source_key: project_id
+            target_key: project_id
+          - source_key: location
+            target_key: location
+          - source_key: cluster_name
+            target_key: cluster_name
+          - source_key: container_name
+            target_key: container_name
+          - source_key: namespace_name
+            target_key: namespace_name
+          - source_key: pod_name
+            target_key: pod_name
+          source_type: k8s_container
+          target_type: k8s_container
+        - label_mappings:
+          - source_key: project_id
+            target_key: project_id
+          - source_key: location
+            target_key: location
+          - source_key: cluster_name
+            target_key: cluster_name
+          - source_key: namespace_name
+            target_key: namespace_name
+          - source_key: pod_name
+            target_key: pod_name
+          source_type: k8s_pod
+          target_type: k8s_pod
+        - label_mappings:
+          - source_key: project_id
+            target_key: project_id
+          - source_key: location
+            target_key: location
+          - source_key: cluster_name
+            target_key: cluster_name
+          - source_key: node_name
+            target_key: node_name
+          source_type: k8s_node
+          target_type: k8s_node
       stackdriver/metrics:
         endpoint: monitoring.googleapis.com:443
         metric:
@@ -235,6 +280,185 @@ data:
           location: CLUSTER_LOCATION
           project_id: PROJECT_ID
     receivers:
+      prometheus/app-metrics:
+        config:
+          global:
+            scrape_interval: 1m
+          scrape_configs:
+          - job_name: prometheus-io-endpoints-pod-type
+            kubernetes_sd_configs:
+            - role: endpoints
+              selectors:
+              - field: spec.nodeName=$NODE_NAME
+                role: pod
+            relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+              - __meta_kubernetes_service_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_service_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: (https?)
+              source_labels:
+              - __meta_kubernetes_service_annotation_prometheus_io_scheme
+              target_label: __scheme__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $$1:$$2
+              source_labels:
+              - __address__
+              - __meta_kubernetes_service_annotation_prometheus_io_port
+              target_label: __address__
+            - action: keep
+              regex: $NODE_NAME
+              source_labels:
+              - __meta_kubernetes_endpoint_node_name
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_namespace
+              target_label: anthos_namespace
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_pod_name
+              target_label: anthos_pod
+            - action: drop
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_pod_container_name
+            - action: keep
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_endpoint_port_name
+          - job_name: prometheus-io-endpoints-container-type
+            kubernetes_sd_configs:
+            - role: endpoints
+              selectors:
+              - field: spec.nodeName=$NODE_NAME
+                role: pod
+            relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+              - __meta_kubernetes_service_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_service_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: (https?)
+              source_labels:
+              - __meta_kubernetes_service_annotation_prometheus_io_scheme
+              target_label: __scheme__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $$1:$$2
+              source_labels:
+              - __address__
+              - __meta_kubernetes_service_annotation_prometheus_io_port
+              target_label: __address__
+            - action: keep
+              regex: $NODE_NAME
+              source_labels:
+              - __meta_kubernetes_endpoint_node_name
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_namespace
+              target_label: anthos_namespace
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_pod_name
+              target_label: anthos_pod
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_pod_container_name
+              target_label: anthos_container
+            - action: keep
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_pod_container_name
+            - action: keep
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_endpoint_port_name
+          - job_name: prometheus-io-pods-pod-type
+            kubernetes_sd_configs:
+            - role: pod
+              selectors:
+              - field: spec.nodeName=$NODE_NAME
+                role: pod
+            relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $$1:$$2
+              source_labels:
+              - __address__
+              - __meta_kubernetes_pod_annotation_prometheus_io_port
+              target_label: __address__
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_namespace
+              target_label: anthos_namespace
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_pod_name
+              target_label: anthos_pod
+            - action: drop
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_pod_container_name
+          - job_name: prometheus-io-pods-container-type
+            kubernetes_sd_configs:
+            - role: pod
+              selectors:
+              - field: spec.nodeName=$NODE_NAME
+                role: pod
+            relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $$1:$$2
+              source_labels:
+              - __address__
+              - __meta_kubernetes_pod_annotation_prometheus_io_port
+              target_label: __address__
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_namespace
+              target_label: anthos_namespace
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_pod_name
+              target_label: anthos_pod
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_pod_container_name
+              target_label: anthos_container
+            - action: keep
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_pod_container_name
       prometheus/metrics:
         config:
           global:
@@ -854,6 +1078,15 @@ data:
         use_start_time_metric: false
     service:
       pipelines:
+        metrics/app-metrics:
+          exporters:
+          - stackdriver/app-metrics
+          processors:
+          - resource
+          - metric_to_resource
+          - infer_resource
+          receivers:
+          - prometheus/app-metrics
         metrics/metrics:
           exporters:
           - stackdriver/metrics


### PR DESCRIPTION
#### Description
- Support application metrics in Cloud Monitoring for Anthos MultiCloud on AWS (k-lite version)

#### Change summary
- Add the configs to scrape application metrics with prometheus annotations

#### Related PRs/Issues
- #8 
- #57 

Signed-off-by: Leon Ziyang Zhang <leonzz@google.com>
