### PR TITLE
cleanup: update CI badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Anthos Samples
 
-![Continuous Integration](https://github.com/GoogleCloudPlatform/anthos-samples/workflows/Continuous%20Integration%20-%20main/Release/badge.svg)
+![Continuous Integration](https://github.com/GoogleCloudPlatform/anthos-samples/workflows/Continuous%20Integration%20-%20Main/Release/badge.svg)
 
 This repository contains code samples for [Anthos](https://cloud.google.com/anthos/docs).
 


### PR DESCRIPTION
Currently the badge is 404ing. 

I think it should be this? https://github.com/GoogleCloudPlatform/anthos-samples/workflows/Continuous%20Integration%20-%20Main/Release/badge.svg 