### PR TITLE
chore: add a new team anthos-multicloud as owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,3 +9,4 @@
 # the Onyx GKE Observability team (go/onyx-observability)
 /aws-logging-monitoring/          @GoogleCloudPlatform/onyx-gke-observability
 /attached-logging-monitoring/     @GoogleCloudPlatform/onyx-gke-observability
+/anthos-multi-cloud/		  @GoogleCloudPlatform/anthos-multicloud


### PR DESCRIPTION
### Fixes
- New PR #124 adds Anthos multi-cloud samples into the repo
- We need to delegate approval ownership to the contributors who work on that 

#### Description
- Create a new Github team called [anthos-multicloud](https://github.com/orgs/GoogleCloudPlatform/teams/anthos-multicloud/members) 
- Add the requested contributors _(as shared by the contributor of PR #124) to the new team
- Add that team as the CodeOwners of the `anthos-multi-cloud` sample directory


