### PR TITLE
cleanup: remove hardcoded profile in AWS provider for GKE on AWS

### DIFF
--- a/anthos-multi-cloud/AWS/provider.tf
+++ b/anthos-multi-cloud/AWS/provider.tf
@@ -24,8 +24,7 @@ terraform {
 }
 
 provider "aws" {
-  profile = "default"
-  region  = var.aws_region
+  region = var.aws_region
 }
 provider "google" {
   project = var.gcp_project_id


### PR DESCRIPTION
### Fixes
Fixes #178

#### Description
- Remove hardcoded AWS profile name from GKE on AWS
- Terraform

#### Change summary
- One line removed
- Fixed whitespaces after parameter was removed

