### PR TITLE
fix: remove zone variable and fetch from vm info

### DIFF
--- a/anthos-bm-gcp-terraform/docs/quickstart.md
+++ b/anthos-bm-gcp-terraform/docs/quickstart.md
@@ -8,7 +8,6 @@
 ```
 project_id       = "<GOOGLE_CLOUD_PROJECT_ID>"
 region           = "<GOOGLE_CLOUD_REGION_TO_USE>"
-zone             = "<GOOGLE_CLOUD_ZONE_TO_USE>"
 credentials_file = "<PATH_TO_GOOGLE_CLOUD_SERVICE_ACCOUNT_FILE>"
 ```
 
@@ -46,7 +45,7 @@ After the Terraform execution completes you are ready to deploy an Anthos cluste
 
 1. SSH into the admin host
 ```sh
-gcloud compute ssh tfadmin@cluster1-abm-ws0-001 --project=<YOUR_PROJECT> --zone=<YOUR_ZONE>
+gcloud compute ssh tfadmin@cluster1-abm-ws0-001 --project=<YOUR_PROJECT> --zone=<ADMIN_VM_ZONE>
 ```
 
 2. Install the Anthos cluster on the provisioned Compute Engine VM based bare metal infrastructure
@@ -97,7 +96,7 @@ You can find your cluster's `kubeconfig` file on the admin machine in the `bmctl
 1. SSH into the admin host _(if you are not already inside it)_:
 ```sh
 # You can copy the command from the output of Terraform run from the previous step
-gcloud compute ssh tfadmin@cluster1-abm-ws0-001 --project=<YOUR_PROJECT> --zone=<YOUR_ZONE>
+gcloud compute ssh tfadmin@cluster1-abm-ws0-001 --project=<YOUR_PROJECT> --zone=<ADMIN_VM_ZONE>
 ```
 
 2. Set the `KUBECONFIG` environment variable with the path to the cluster's configuration file to run `kubectl` commands on the cluster.
@@ -133,7 +132,7 @@ You can cleanup the cluster setup in two ways:
 - First deregister the cluster before deleting all the resources created by Terraform
   ```sh
   # SSH into the admin host
-  gcloud compute ssh tfadmin@cluster1-abm-ws0-001 --project=<YOUR_PROJECT> --zone=<YOUR_ZONE>
+  gcloud compute ssh tfadmin@cluster1-abm-ws0-001 --project=<YOUR_PROJECT> --zone=<ADMIN_VM_ZONE>
 
   # Reset the cluster
   export CLUSTER_ID=cluster1

--- a/anthos-bm-gcp-terraform/modules/vm/outputs.tf
+++ b/anthos-bm-gcp-terraform/modules/vm/outputs.tf
@@ -20,6 +20,7 @@ output "vm_info" {
       for vm_details in group : [
         for detail in vm_details.instances_details : {
           hostname   = detail.name
+          zone       = detail.zone
           internalIp = detail.network_interface.0.network_ip
           externalIp = detail.network_interface.0.access_config.0.nat_ip
         }

--- a/anthos-bm-gcp-terraform/outputs.tf
+++ b/anthos-bm-gcp-terraform/outputs.tf
@@ -23,7 +23,7 @@ output "admin_vm_ssh" {
     "##   (Note that the 1st command should have you SSH'ed into the admin host)   ##",
     "################################################################################",
     "",
-    "> gcloud compute ssh ${var.username}@${local.admin_vm_hostnames[0]} --project=${var.project_id} --zone=${var.zone}",
+    "> gcloud compute ssh ${var.username}@${local.admin_vm_hostnames[0]} --project=${var.project_id} --zone=${local.vm_zone}",
     "",
     "# ------------------------------------------------------------------------------",
     "# You must be SSH'ed into the admin host ${local.admin_vm_hostnames[0]} as ${var.username} user now",

--- a/anthos-bm-gcp-terraform/terraform.tfvars.sample
+++ b/anthos-bm-gcp-terraform/terraform.tfvars.sample
@@ -1,6 +1,5 @@
 project_id                    = "<GOOGLE_CLOUD_PROJECT_ID>"
 region                        = "<GOOGLE_CLOUD_REGION_TO_USE>"
-zone                          = "<GOOGLE_CLOUD_ZONE_TO_USE>"
 credentials_file              = "<PATH_TO_GOOGLE_CLOUD_SERVICE_ACCOUNT_FILE>"
 abm_cluster_id                = "cluster1"
 anthos_service_account_name   = "baremetal-gcr"

--- a/anthos-bm-gcp-terraform/variables.tf
+++ b/anthos-bm-gcp-terraform/variables.tf
@@ -38,12 +38,6 @@ variable "region" {
   default     = "us-central1"
 }
 
-variable "zone" {
-  description = "Zone within the selected Google Cloud Region that is to be used"
-  type        = string
-  default     = "us-central1-a"
-}
-
 variable "username" {
   description = "The name of the user to be created on each Compute Engine VM to execute the init script"
   type        = string

--- a/anthos-bm-gcp-terraform/versions.tf
+++ b/anthos-bm-gcp-terraform/versions.tf
@@ -38,13 +38,11 @@ terraform {
 provider "google" {
   project     = var.project_id
   region      = var.region
-  zone        = var.zone
   credentials = file(var.credentials_file)
 }
 
 provider "google-beta" {
   project     = var.project_id
   region      = var.region
-  zone        = var.zone
   credentials = file(var.credentials_file)
 }


### PR DESCRIPTION
### Fixes #186 

#### Description
- Please read the description from the issue #186 

#### Change summary
- We fix the issue by extracting the zone information from the created VMs
- We then use this as the zone everywhere
- We remove references to zone everywhere else

#### Related PRs/Issues
- This change needs to update the following docs:
    - [ABM DOc for GCE Terraform 1.8](https://cloud.google.com/anthos/clusters/docs/bare-metal/1.8/try/gce-vms-tf)
    - [ABM DOc for GCE Terraform 1.9](https://cloud.google.com/anthos/clusters/docs/bare-metal/1.9/try/gce-vms-tf)
    - [ABM DOc for GCE Terraform 1.10](https://cloud.google.com/anthos/clusters/docs/bare-metal/1.10/try/gce-vms-tf)


