### PR TITLE
fix: zone mismatch for vm

### DIFF
--- a/anthos-bm-gcp-terraform/main.tf
+++ b/anthos-bm-gcp-terraform/main.tf
@@ -134,6 +134,7 @@ module "admin_vm_hosts" {
     module.enable_google_apis_secondary
   ]
   region            = var.region
+  zone              = var.zone
   network           = var.network
   vm_names          = local.admin_vm_name
   instance_template = module.instance_template.self_link
@@ -146,6 +147,7 @@ module "controlplane_vm_hosts" {
     module.enable_google_apis_secondary
   ]
   region            = var.region
+  zone              = var.zone
   network           = var.network
   vm_names          = local.controlplane_vm_names
   instance_template = module.instance_template.self_link
@@ -158,6 +160,7 @@ module "worker_vm_hosts" {
     module.enable_google_apis_secondary
   ]
   region            = var.region
+  zone              = var.zone
   network           = var.network
   vm_names          = local.worker_vm_names
   instance_template = module.instance_template.self_link

--- a/anthos-bm-gcp-terraform/modules/vm/main.tf
+++ b/anthos-bm-gcp-terraform/modules/vm/main.tf
@@ -24,7 +24,7 @@ module "compute_instance" {
   source            = "terraform-google-modules/vm/google//modules/compute_instance"
   version           = "~> 7.6.0"
   instance_template = var.instance_template
-  region            = var.region
+  zone              = var.zone
   for_each          = toset(var.vm_names)
   hostname          = each.value
   network           = var.network # --network default

--- a/anthos-bm-gcp-terraform/modules/vm/variables.tf
+++ b/anthos-bm-gcp-terraform/modules/vm/variables.tf
@@ -15,9 +15,15 @@
  */
 
 variable "region" {
-  description = "Google Cloud Region in which the VMs should be provisioned"
+  description = "Google Cloud Region in which the External IP addresses should be provisioned"
   type        = string
   default     = "us-central1"
+}
+
+variable "zone" {
+  description = "Google Cloud Zone in which the VMs should be provisioned"
+  type        = string
+  default     = "us-central1-a"
 }
 
 variable "network" {

--- a/anthos-bm-gcp-terraform/test/unit/main_test.go
+++ b/anthos-bm-gcp-terraform/test/unit/main_test.go
@@ -1,20 +1,16 @@
-//nolint:golint
-//TODO:https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/926
-/*
-Copyright 2021 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package unit
 

--- a/anthos-bm-gcp-terraform/test/unit/module_external_ip_test.go
+++ b/anthos-bm-gcp-terraform/test/unit/module_external_ip_test.go
@@ -1,20 +1,16 @@
-//nolint:golint
-//TODO:https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/926
-/*
-Copyright 2021 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package unit
 

--- a/anthos-bm-gcp-terraform/test/unit/module_init_test.go
+++ b/anthos-bm-gcp-terraform/test/unit/module_init_test.go
@@ -1,20 +1,16 @@
-//nolint:golint
-//TODO:https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/926
-/*
-Copyright 2021 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package unit
 

--- a/anthos-bm-gcp-terraform/test/unit/module_vm_test.go
+++ b/anthos-bm-gcp-terraform/test/unit/module_vm_test.go
@@ -1,20 +1,16 @@
-//nolint:golint
-//TODO:https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/926
-/*
-Copyright 2021 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package unit
 

--- a/anthos-bm-gcp-terraform/test/util/cluster_yaml.go
+++ b/anthos-bm-gcp-terraform/test/util/cluster_yaml.go
@@ -1,20 +1,16 @@
-//nolint:golint
-//TODO:https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/926
-/*
-Copyright 2021 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package util
 
@@ -78,6 +74,6 @@ type ControlPlane struct {
 // definition for the resource kind Cluster in the Yaml for the
 // Anthos Baremetal cluster
 type NodePoolSpec struct {
-	ClusterName string `yaml:"clusterName"`
+	ClusterName string  `yaml:"clusterName"`
 	Nodes       *[]Node `yaml:"nodes"`
 }

--- a/anthos-bm-gcp-terraform/test/util/functions.go
+++ b/anthos-bm-gcp-terraform/test/util/functions.go
@@ -1,20 +1,16 @@
-//nolint:golint
-//TODO:https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/926
-/*
-Copyright 2021 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package util
 

--- a/anthos-bm-gcp-terraform/test/util/module_external_ip.go
+++ b/anthos-bm-gcp-terraform/test/util/module_external_ip.go
@@ -1,20 +1,16 @@
-//nolint:golint
-//TODO:https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/926
-/*
-Copyright 2021 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package util
 

--- a/anthos-bm-gcp-terraform/test/util/module_init.go
+++ b/anthos-bm-gcp-terraform/test/util/module_init.go
@@ -1,20 +1,16 @@
-//nolint:golint
-//TODO:https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/926
-/*
-Copyright 2021 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package util
 

--- a/anthos-bm-gcp-terraform/test/util/module_main.go
+++ b/anthos-bm-gcp-terraform/test/util/module_main.go
@@ -1,20 +1,16 @@
-//nolint:golint
-//TODO:https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/926
-/*
-Copyright 2021 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package util
 

--- a/anthos-bm-gcp-terraform/test/util/module_vm.go
+++ b/anthos-bm-gcp-terraform/test/util/module_vm.go
@@ -30,6 +30,7 @@ type VMInstancePlan struct {
 // to be modified
 type VMVariables struct {
 	Region           *Variable       `json:"region"`
+	Zone             *Variable       `json:"zone"`
 	Network          *Variable       `json:"network"`
 	Names            *VMVarValueList `json:"vm_names"`
 	InstanceTemplate *Variable       `json:"instance_template"`

--- a/anthos-bm-gcp-terraform/test/util/module_vm.go
+++ b/anthos-bm-gcp-terraform/test/util/module_vm.go
@@ -1,20 +1,16 @@
-//nolint:golint
-//TODO:https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/926
-/*
-Copyright 2021 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package util
 

--- a/anthos-bm-gcp-terraform/test/util/tf_module.go
+++ b/anthos-bm-gcp-terraform/test/util/tf_module.go
@@ -1,20 +1,16 @@
-//nolint:golint
-//TODO:https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/926
-/*
-Copyright 2021 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package util
 
@@ -62,7 +58,7 @@ type TFValues struct {
 	Disk              []Disk           `json:"disk"`
 	ServiceAccount    []ServiceAccount `json:"service_account"`
 	NetworkInterfaces []Interface      `json:"network_interface"`
-	Gpu               *Gpu              `json:"gpu"`
+	Gpu               *Gpu             `json:"gpu"`
 }
 
 // TFProvisioner represents the provisioners configured in the terraform output


### PR DESCRIPTION
### Fixes #186 

#### Description
- Please read the description from the issue #186 

#### Change summary
- We fix the issue by passing in the zone information to the VM creation module.

#### Related PRs/Issues
- This PR also has fixes from https://github.com/GoogleCloudPlatform/anthos-samples/pull/191. It was mistakenly merged into this because the wrong branch being set there