### PR TITLE
fix: update API IAM policy

### DIFF
--- a/anthos-multi-cloud/AWS/modules/iam/main.tf
+++ b/anthos-multi-cloud/AWS/modules/iam/main.tf
@@ -71,6 +71,7 @@ data "aws_iam_policy_document" "api_policy_document" {
       "elasticloadbalancing:CreateListener",
       "elasticloadbalancing:AddTags",
       "elasticloadbalancing:ModifyTargetGroupAttributes",
+      "ec2:ModifyNetworkInterfaceAttribute",
       "ec2:DescribeAccountAttributes",
       "ec2:DescribeInternetGateways",
       "ec2:RunInstances",


### PR DESCRIPTION
to include ec2:ModifyNetworkInterfaceAttribute. This is a new required IAM permission [0].

[0] https://cloud.google.com/anthos/clusters/docs/multi-cloud/aws/how-to/create-aws-iam-roles#create_role.

### Fixes ISSUE_NO_HERE
- If you still haven't done yet, then please do create an issue in the repository before opening this PR

#### Description
- Brief description of the issue/purpose of this PR
- Include environment _(e.g: Linux/Ubuntu running terraform v14.10 etc)_ if relavant

#### Change summary
- List of changes done in this PR

#### Related PRs/Issues
- List any related PRs and Issues


