### PR TITLE
feat: Enable nested virtualization support for ABM Terraform installation on GCE

### DIFF
--- a/anthos-bm-gcp-terraform/main.tf
+++ b/anthos-bm-gcp-terraform/main.tf
@@ -101,18 +101,19 @@ module "instance_template" {
     module.enable_google_apis_secondary
   ]
   # fetched from previous module to explicitely express dependency
-  project_id           = module.enable_google_apis_secondary.project_id
-  region               = var.region           # --zone=${ZONE}
-  source_image         = var.image            # --image=ubuntu-2004-focal-v20210429
-  source_image_family  = var.image_family     # --image-family=ubuntu-2004-lts
-  source_image_project = var.image_project    # --image-project=ubuntu-os-cloud
-  machine_type         = var.machine_type     # --machine-type $MACHINE_TYPE
-  disk_size_gb         = var.boot_disk_size   # --boot-disk-size 200G
-  disk_type            = var.boot_disk_type   # --boot-disk-type pd-ssd
-  network              = var.network          # --network default
-  tags                 = var.tags             # --tags http-server,https-server
-  min_cpu_platform     = var.min_cpu_platform # --min-cpu-platform "Intel Haswell"
-  can_ip_forward       = true                 # --can-ip-forward
+  project_id                   = module.enable_google_apis_secondary.project_id
+  region                       = var.region                       # --zone=${ZONE}
+  source_image                 = var.image                        # --image=ubuntu-2004-focal-v20210429
+  source_image_family          = var.image_family                 # --image-family=ubuntu-2004-lts
+  source_image_project         = var.image_project                # --image-project=ubuntu-os-cloud
+  machine_type                 = var.machine_type                 # --machine-type $MACHINE_TYPE
+  disk_size_gb                 = var.boot_disk_size               # --boot-disk-size 200G
+  disk_type                    = var.boot_disk_type               # --boot-disk-type pd-ssd
+  network                      = var.network                      # --network default
+  tags                         = var.tags                         # --tags http-server,https-server
+  min_cpu_platform             = var.min_cpu_platform             # --min-cpu-platform "Intel Haswell"
+  can_ip_forward               = true                             # --can-ip-forward
+  enable_nested_virtualization = var.enable_nested_virtualization # --enable-nested-virtualization
   # Disable oslogin explicitly since we rely on metadata based ssh-key (issues/70).
   metadata = {
     enable-oslogin = "false"

--- a/anthos-bm-gcp-terraform/main.tf
+++ b/anthos-bm-gcp-terraform/main.tf
@@ -102,18 +102,18 @@ module "instance_template" {
   ]
   # fetched from previous module to explicitely express dependency
   project_id                   = module.enable_google_apis_secondary.project_id
-  region                       = var.region           # --zone=${ZONE}
-  source_image                 = var.image            # --image=ubuntu-2004-focal-v20210429
-  source_image_family          = var.image_family     # --image-family=ubuntu-2004-lts
-  source_image_project         = var.image_project    # --image-project=ubuntu-os-cloud
-  machine_type                 = var.machine_type     # --machine-type $MACHINE_TYPE
-  disk_size_gb                 = var.boot_disk_size   # --boot-disk-size 200G
-  disk_type                    = var.boot_disk_type   # --boot-disk-type pd-ssd
-  network                      = var.network          # --network default
-  tags                         = var.tags             # --tags http-server,https-server
-  min_cpu_platform             = var.min_cpu_platform # --min-cpu-platform "Intel Haswell"
-  can_ip_forward               = true                 # --can-ip-forward
-  enable_nested_virtualization = true                 # --enable-nested-virtualization
+  region                       = var.region                       # --zone=${ZONE}
+  source_image                 = var.image                        # --image=ubuntu-2004-focal-v20210429
+  source_image_family          = var.image_family                 # --image-family=ubuntu-2004-lts
+  source_image_project         = var.image_project                # --image-project=ubuntu-os-cloud
+  machine_type                 = var.machine_type                 # --machine-type $MACHINE_TYPE
+  disk_size_gb                 = var.boot_disk_size               # --boot-disk-size 200G
+  disk_type                    = var.boot_disk_type               # --boot-disk-type pd-ssd
+  network                      = var.network                      # --network default
+  tags                         = var.tags                         # --tags http-server,https-server
+  min_cpu_platform             = var.min_cpu_platform             # --min-cpu-platform "Intel Haswell"
+  can_ip_forward               = true                             # --can-ip-forward
+  enable_nested_virtualization = var.enable_nested_virtualization # --enable-nested-virtualization
   # Disable oslogin explicitly since we rely on metadata based ssh-key (issues/70).
   metadata = {
     enable-oslogin = "false"

--- a/anthos-bm-gcp-terraform/main.tf
+++ b/anthos-bm-gcp-terraform/main.tf
@@ -102,18 +102,18 @@ module "instance_template" {
   ]
   # fetched from previous module to explicitely express dependency
   project_id                   = module.enable_google_apis_secondary.project_id
-  region                       = var.region                       # --zone=${ZONE}
-  source_image                 = var.image                        # --image=ubuntu-2004-focal-v20210429
-  source_image_family          = var.image_family                 # --image-family=ubuntu-2004-lts
-  source_image_project         = var.image_project                # --image-project=ubuntu-os-cloud
-  machine_type                 = var.machine_type                 # --machine-type $MACHINE_TYPE
-  disk_size_gb                 = var.boot_disk_size               # --boot-disk-size 200G
-  disk_type                    = var.boot_disk_type               # --boot-disk-type pd-ssd
-  network                      = var.network                      # --network default
-  tags                         = var.tags                         # --tags http-server,https-server
-  min_cpu_platform             = var.min_cpu_platform             # --min-cpu-platform "Intel Haswell"
-  can_ip_forward               = true                             # --can-ip-forward
-  enable_nested_virtualization = var.enable_nested_virtualization # --enable-nested-virtualization
+  region                       = var.region           # --zone=${ZONE}
+  source_image                 = var.image            # --image=ubuntu-2004-focal-v20210429
+  source_image_family          = var.image_family     # --image-family=ubuntu-2004-lts
+  source_image_project         = var.image_project    # --image-project=ubuntu-os-cloud
+  machine_type                 = var.machine_type     # --machine-type $MACHINE_TYPE
+  disk_size_gb                 = var.boot_disk_size   # --boot-disk-size 200G
+  disk_type                    = var.boot_disk_type   # --boot-disk-type pd-ssd
+  network                      = var.network          # --network default
+  tags                         = var.tags             # --tags http-server,https-server
+  min_cpu_platform             = var.min_cpu_platform # --min-cpu-platform "Intel Haswell"
+  can_ip_forward               = true                 # --can-ip-forward
+  enable_nested_virtualization = true                 # --enable-nested-virtualization
   # Disable oslogin explicitly since we rely on metadata based ssh-key (issues/70).
   metadata = {
     enable-oslogin = "false"

--- a/anthos-bm-gcp-terraform/test/unit/main_test.go
+++ b/anthos-bm-gcp-terraform/test/unit/main_test.go
@@ -47,6 +47,7 @@ func TestUnit_MainScript(goTester *testing.T) {
 	resourcesPath := "./resources"
 	username := "test_username"
 	minCPUPlatform := "test_cpu_platform"
+	enableNestedVirtualization := "test_nested_virtualization"
 	machineType := "test_machine_type"
 	image := "test_image"
 	imageProject := "test_image_project"
@@ -85,28 +86,29 @@ func TestUnit_MainScript(goTester *testing.T) {
 	tfPlanOutput := "terraform_test.tfplan"
 	tfPlanOutputArg := fmt.Sprintf("-out=%s", tfPlanOutput)
 	tfVarsMap := map[string]interface{}{
-		"project_id":                  projectID,
-		"credentials_file":            credentialsFile,
-		"resources_path":              resourcesPath,
-		"region":                      region,
-		"zone":                        zone,
-		"username":                    username,
-		"min_cpu_platform":            minCPUPlatform,
-		"machine_type":                machineType,
-		"image":                       image,
-		"image_project":               imageProject,
-		"image_family":                imageFamily,
-		"boot_disk_type":              bootDiskType,
-		"boot_disk_size":              bootDiskSize,
-		"network":                     network,
-		"tags":                        tags,
-		"access_scopes":               accessScopes,
-		"anthos_service_account_name": anthosServiceAccountName,
-		"primary_apis":                primaryApis,
-		"secondary_apis":              secondaryApis,
-		"abm_cluster_id":              abmClusterID,
-		"instance_count":              instanceCount,
-		"gpu":                         gpu,
+		"project_id":                   projectID,
+		"credentials_file":             credentialsFile,
+		"resources_path":               resourcesPath,
+		"region":                       region,
+		"zone":                         zone,
+		"username":                     username,
+		"min_cpu_platform":             minCPUPlatform,
+		"enable_nested_virtualization": enableNestedVirtualization,
+		"machine_type":                 machineType,
+		"image":                        image,
+		"image_project":                imageProject,
+		"image_family":                 imageFamily,
+		"boot_disk_type":               bootDiskType,
+		"boot_disk_size":               bootDiskSize,
+		"network":                      network,
+		"tags":                         tags,
+		"access_scopes":                accessScopes,
+		"anthos_service_account_name":  anthosServiceAccountName,
+		"primary_apis":                 primaryApis,
+		"secondary_apis":               secondaryApis,
+		"abm_cluster_id":               abmClusterID,
+		"instance_count":               instanceCount,
+		"gpu":                          gpu,
 	}
 
 	tfOptions := terraform.WithDefaultRetryableErrors(goTester, &terraform.Options{
@@ -310,6 +312,14 @@ func TestUnit_MainScript_ValidateDefaults(goTester *testing.T) {
 		"Intel Haswell",
 		terraformPlan.Variables.MinCPUPlatform.Value,
 		"Variable does not match expected default value: min_cpu_platform.",
+	)
+
+	// verify input variable enable_nested_virtualization in plan matches the default value
+	assert.Equal(
+		goTester,
+		"true",
+		terraformPlan.Variables.EnableNestedVirtualization.Value,
+		"Variable does not match expected default value: enable_nested_virtualization.",
 	)
 
 	// verify input variable image in plan matches the default value

--- a/anthos-bm-gcp-terraform/test/unit/main_test.go
+++ b/anthos-bm-gcp-terraform/test/unit/main_test.go
@@ -47,7 +47,6 @@ func TestUnit_MainScript(goTester *testing.T) {
 	resourcesPath := "./resources"
 	username := "test_username"
 	minCPUPlatform := "test_cpu_platform"
-	enableNestedVirtualization := "test_nested_virtualization"
 	machineType := "test_machine_type"
 	image := "test_image"
 	imageProject := "test_image_project"
@@ -86,29 +85,28 @@ func TestUnit_MainScript(goTester *testing.T) {
 	tfPlanOutput := "terraform_test.tfplan"
 	tfPlanOutputArg := fmt.Sprintf("-out=%s", tfPlanOutput)
 	tfVarsMap := map[string]interface{}{
-		"project_id":                   projectID,
-		"credentials_file":             credentialsFile,
-		"resources_path":               resourcesPath,
-		"region":                       region,
-		"zone":                         zone,
-		"username":                     username,
-		"min_cpu_platform":             minCPUPlatform,
-		"enable_nested_virtualization": enableNestedVirtualization,
-		"machine_type":                 machineType,
-		"image":                        image,
-		"image_project":                imageProject,
-		"image_family":                 imageFamily,
-		"boot_disk_type":               bootDiskType,
-		"boot_disk_size":               bootDiskSize,
-		"network":                      network,
-		"tags":                         tags,
-		"access_scopes":                accessScopes,
-		"anthos_service_account_name":  anthosServiceAccountName,
-		"primary_apis":                 primaryApis,
-		"secondary_apis":               secondaryApis,
-		"abm_cluster_id":               abmClusterID,
-		"instance_count":               instanceCount,
-		"gpu":                          gpu,
+		"project_id":                  projectID,
+		"credentials_file":            credentialsFile,
+		"resources_path":              resourcesPath,
+		"region":                      region,
+		"zone":                        zone,
+		"username":                    username,
+		"min_cpu_platform":            minCPUPlatform,
+		"machine_type":                machineType,
+		"image":                       image,
+		"image_project":               imageProject,
+		"image_family":                imageFamily,
+		"boot_disk_type":              bootDiskType,
+		"boot_disk_size":              bootDiskSize,
+		"network":                     network,
+		"tags":                        tags,
+		"access_scopes":               accessScopes,
+		"anthos_service_account_name": anthosServiceAccountName,
+		"primary_apis":                primaryApis,
+		"secondary_apis":              secondaryApis,
+		"abm_cluster_id":              abmClusterID,
+		"instance_count":              instanceCount,
+		"gpu":                         gpu,
 	}
 
 	tfOptions := terraform.WithDefaultRetryableErrors(goTester, &terraform.Options{
@@ -312,14 +310,6 @@ func TestUnit_MainScript_ValidateDefaults(goTester *testing.T) {
 		"Intel Haswell",
 		terraformPlan.Variables.MinCPUPlatform.Value,
 		"Variable does not match expected default value: min_cpu_platform.",
-	)
-
-	// verify input variable enable_nested_virtualization in plan matches the default value
-	assert.Equal(
-		goTester,
-		"true",
-		terraformPlan.Variables.EnableNestedVirtualization.Value,
-		"Variable does not match expected default value: enable_nested_virtualization.",
 	)
 
 	// verify input variable image in plan matches the default value

--- a/anthos-bm-gcp-terraform/test/unit/main_test.go
+++ b/anthos-bm-gcp-terraform/test/unit/main_test.go
@@ -47,6 +47,7 @@ func TestUnit_MainScript(goTester *testing.T) {
 	resourcesPath := "./resources"
 	username := "test_username"
 	minCPUPlatform := "test_cpu_platform"
+	enableNestedVirtualization := "true"
 	machineType := "test_machine_type"
 	image := "test_image"
 	imageProject := "test_image_project"
@@ -85,28 +86,29 @@ func TestUnit_MainScript(goTester *testing.T) {
 	tfPlanOutput := "terraform_test.tfplan"
 	tfPlanOutputArg := fmt.Sprintf("-out=%s", tfPlanOutput)
 	tfVarsMap := map[string]interface{}{
-		"project_id":                  projectID,
-		"credentials_file":            credentialsFile,
-		"resources_path":              resourcesPath,
-		"region":                      region,
-		"zone":                        zone,
-		"username":                    username,
-		"min_cpu_platform":            minCPUPlatform,
-		"machine_type":                machineType,
-		"image":                       image,
-		"image_project":               imageProject,
-		"image_family":                imageFamily,
-		"boot_disk_type":              bootDiskType,
-		"boot_disk_size":              bootDiskSize,
-		"network":                     network,
-		"tags":                        tags,
-		"access_scopes":               accessScopes,
-		"anthos_service_account_name": anthosServiceAccountName,
-		"primary_apis":                primaryApis,
-		"secondary_apis":              secondaryApis,
-		"abm_cluster_id":              abmClusterID,
-		"instance_count":              instanceCount,
-		"gpu":                         gpu,
+		"project_id":                   projectID,
+		"credentials_file":             credentialsFile,
+		"resources_path":               resourcesPath,
+		"region":                       region,
+		"zone":                         zone,
+		"username":                     username,
+		"min_cpu_platform":             minCPUPlatform,
+		"enable_nested_virtualization": enableNestedVirtualization,
+		"machine_type":                 machineType,
+		"image":                        image,
+		"image_project":                imageProject,
+		"image_family":                 imageFamily,
+		"boot_disk_type":               bootDiskType,
+		"boot_disk_size":               bootDiskSize,
+		"network":                      network,
+		"tags":                         tags,
+		"access_scopes":                accessScopes,
+		"anthos_service_account_name":  anthosServiceAccountName,
+		"primary_apis":                 primaryApis,
+		"secondary_apis":               secondaryApis,
+		"abm_cluster_id":               abmClusterID,
+		"instance_count":               instanceCount,
+		"gpu":                          gpu,
 	}
 
 	tfOptions := terraform.WithDefaultRetryableErrors(goTester, &terraform.Options{
@@ -310,6 +312,14 @@ func TestUnit_MainScript_ValidateDefaults(goTester *testing.T) {
 		"Intel Haswell",
 		terraformPlan.Variables.MinCPUPlatform.Value,
 		"Variable does not match expected default value: min_cpu_platform.",
+	)
+
+	// verify input variable enable_nested_virtualization in plan matches the default value
+	assert.Equal(
+		goTester,
+		"true",
+		terraformPlan.Variables.EnableNestedVirtualization.Value,
+		"Variable does not match expected default value: enable_nested_virtualization.",
 	)
 
 	// verify input variable image in plan matches the default value

--- a/anthos-bm-gcp-terraform/test/util/module_main.go
+++ b/anthos-bm-gcp-terraform/test/util/module_main.go
@@ -26,28 +26,29 @@ type MainModulePlan struct {
 // script. When new variables are added to the script this struct needs to be
 // modified
 type MainVariables struct {
-	ProjectID                *Variable     `json:"project_id"`
-	Region                   *Variable     `json:"region"`
-	Zone                     *Variable     `json:"zone"`
-	Network                  *Variable     `json:"network"`
-	Username                 *Variable     `json:"username"`
-	ABMClusterID             *Variable     `json:"abm_cluster_id"`
-	AnthosServiceAccountName *Variable     `json:"anthos_service_account_name"`
-	BootDiskSize             *Variable     `json:"boot_disk_size"`
-	BootDiskType             *Variable     `json:"boot_disk_type"`
-	CrendetialsFile          *Variable     `json:"credentials_file"`
-	ResourcesPath            *Variable     `json:"resources_path"`
-	Image                    *Variable     `json:"image"`
-	ImageFamily              *Variable     `json:"image_family"`
-	ImageProject             *Variable     `json:"image_project"`
-	MachineType              *Variable     `json:"machine_type"`
-	MinCPUPlatform           *Variable     `json:"min_cpu_platform"`
-	Tags                     *ListVariable `json:"tags"`
-	AccessScope              *ListVariable `json:"access_scopes"`
-	PrimaryAPIs              *ListVariable `json:"primary_apis"`
-	SecondaryAPIs            *ListVariable `json:"secondary_apis"`
-	InstanceCount            *MapVariable  `json:"instance_count"`
-	Gpu                      *GpuVariable  `json:"gpu"`
+	ProjectID                  *Variable     `json:"project_id"`
+	Region                     *Variable     `json:"region"`
+	Zone                       *Variable     `json:"zone"`
+	Network                    *Variable     `json:"network"`
+	Username                   *Variable     `json:"username"`
+	ABMClusterID               *Variable     `json:"abm_cluster_id"`
+	AnthosServiceAccountName   *Variable     `json:"anthos_service_account_name"`
+	BootDiskSize               *Variable     `json:"boot_disk_size"`
+	BootDiskType               *Variable     `json:"boot_disk_type"`
+	CrendetialsFile            *Variable     `json:"credentials_file"`
+	ResourcesPath              *Variable     `json:"resources_path"`
+	Image                      *Variable     `json:"image"`
+	ImageFamily                *Variable     `json:"image_family"`
+	ImageProject               *Variable     `json:"image_project"`
+	MachineType                *Variable     `json:"machine_type"`
+	MinCPUPlatform             *Variable     `json:"min_cpu_platform"`
+	EnableNestedVirtualization *Variable     `json:"enable_nested_virtualization"`
+	Tags                       *ListVariable `json:"tags"`
+	AccessScope                *ListVariable `json:"access_scopes"`
+	PrimaryAPIs                *ListVariable `json:"primary_apis"`
+	SecondaryAPIs              *ListVariable `json:"secondary_apis"`
+	InstanceCount              *MapVariable  `json:"instance_count"`
+	Gpu                        *GpuVariable  `json:"gpu"`
 }
 
 // MainPlannedValues represents the planned state of the terraform run resulting

--- a/anthos-bm-gcp-terraform/test/util/module_main.go
+++ b/anthos-bm-gcp-terraform/test/util/module_main.go
@@ -26,29 +26,28 @@ type MainModulePlan struct {
 // script. When new variables are added to the script this struct needs to be
 // modified
 type MainVariables struct {
-	ProjectID                  *Variable     `json:"project_id"`
-	Region                     *Variable     `json:"region"`
-	Zone                       *Variable     `json:"zone"`
-	Network                    *Variable     `json:"network"`
-	Username                   *Variable     `json:"username"`
-	ABMClusterID               *Variable     `json:"abm_cluster_id"`
-	AnthosServiceAccountName   *Variable     `json:"anthos_service_account_name"`
-	BootDiskSize               *Variable     `json:"boot_disk_size"`
-	BootDiskType               *Variable     `json:"boot_disk_type"`
-	CrendetialsFile            *Variable     `json:"credentials_file"`
-	ResourcesPath              *Variable     `json:"resources_path"`
-	Image                      *Variable     `json:"image"`
-	ImageFamily                *Variable     `json:"image_family"`
-	ImageProject               *Variable     `json:"image_project"`
-	MachineType                *Variable     `json:"machine_type"`
-	MinCPUPlatform             *Variable     `json:"min_cpu_platform"`
-	EnableNestedVirtualization *Variable     `json:"enable_nested_virtualization"`
-	Tags                       *ListVariable `json:"tags"`
-	AccessScope                *ListVariable `json:"access_scopes"`
-	PrimaryAPIs                *ListVariable `json:"primary_apis"`
-	SecondaryAPIs              *ListVariable `json:"secondary_apis"`
-	InstanceCount              *MapVariable  `json:"instance_count"`
-	Gpu                        *GpuVariable  `json:"gpu"`
+	ProjectID                *Variable     `json:"project_id"`
+	Region                   *Variable     `json:"region"`
+	Zone                     *Variable     `json:"zone"`
+	Network                  *Variable     `json:"network"`
+	Username                 *Variable     `json:"username"`
+	ABMClusterID             *Variable     `json:"abm_cluster_id"`
+	AnthosServiceAccountName *Variable     `json:"anthos_service_account_name"`
+	BootDiskSize             *Variable     `json:"boot_disk_size"`
+	BootDiskType             *Variable     `json:"boot_disk_type"`
+	CrendetialsFile          *Variable     `json:"credentials_file"`
+	ResourcesPath            *Variable     `json:"resources_path"`
+	Image                    *Variable     `json:"image"`
+	ImageFamily              *Variable     `json:"image_family"`
+	ImageProject             *Variable     `json:"image_project"`
+	MachineType              *Variable     `json:"machine_type"`
+	MinCPUPlatform           *Variable     `json:"min_cpu_platform"`
+	Tags                     *ListVariable `json:"tags"`
+	AccessScope              *ListVariable `json:"access_scopes"`
+	PrimaryAPIs              *ListVariable `json:"primary_apis"`
+	SecondaryAPIs            *ListVariable `json:"secondary_apis"`
+	InstanceCount            *MapVariable  `json:"instance_count"`
+	Gpu                      *GpuVariable  `json:"gpu"`
 }
 
 // MainPlannedValues represents the planned state of the terraform run resulting

--- a/anthos-bm-gcp-terraform/test/util/tf_module.go
+++ b/anthos-bm-gcp-terraform/test/util/tf_module.go
@@ -36,30 +36,30 @@ type TFResource struct {
 // JSON output of terraform plan. Note that this is a union of all possible
 // values for any modules used in this script
 type TFValues struct {
-	Name                       string           `json:"name"`
-	Index                      string           `json:"index"`
-	Region                     string           `json:"region"`
-	Zone                       string           `json:"zone"`
-	AddressType                string           `json:"address_type"`
-	InstanceTemplate           string           `json:"source_instance_template"`
-	FileName                   string           `json:"filename"`
-	FilePermissions            string           `json:"file_permission"`
-	DirPermissions             string           `json:"directory_permission"`
-	CryptoAlgorithm            string           `json:"algorithm"`
-	Content                    string           `json:"content"`
-	Project                    string           `json:"project"`
-	ImageFamily                string           `json:"family"`
-	MachineType                string           `json:"machine_type"`
-	MinCPUPlatform             string           `json:"min_cpu_platform"`
-	EnableNestedVirtualization bool             `json:"enable_nested_virtualization"`
-	Service                    string           `json:"service"`
-	CanIPForward               bool             `json:"can_ip_forward"`
-	Trigger                    Trigger          `json:"triggers"`
-	Tags                       []string         `json:"tags"`
-	Disk                       []Disk           `json:"disk"`
-	ServiceAccount             []ServiceAccount `json:"service_account"`
-	NetworkInterfaces          []Interface      `json:"network_interface"`
-	Gpu                        *Gpu             `json:"gpu"`
+	Name                    string                    `json:"name"`
+	Index                   string                    `json:"index"`
+	Region                  string                    `json:"region"`
+	Zone                    string                    `json:"zone"`
+	AddressType             string                    `json:"address_type"`
+	InstanceTemplate        string                    `json:"source_instance_template"`
+	FileName                string                    `json:"filename"`
+	FilePermissions         string                    `json:"file_permission"`
+	DirPermissions          string                    `json:"directory_permission"`
+	CryptoAlgorithm         string                    `json:"algorithm"`
+	Content                 string                    `json:"content"`
+	Project                 string                    `json:"project"`
+	ImageFamily             string                    `json:"family"`
+	MachineType             string                    `json:"machine_type"`
+	MinCPUPlatform          string                    `json:"min_cpu_platform"`
+	AdvancedMachineFeatures []AdvancedMachineFeatures `json:"advanced_machine_features"`
+	Service                 string                    `json:"service"`
+	CanIPForward            bool                      `json:"can_ip_forward"`
+	Trigger                 Trigger                   `json:"triggers"`
+	Tags                    []string                  `json:"tags"`
+	Disk                    []Disk                    `json:"disk"`
+	ServiceAccount          []ServiceAccount          `json:"service_account"`
+	NetworkInterfaces       []Interface               `json:"network_interface"`
+	Gpu                     *Gpu                      `json:"gpu"`
 }
 
 // TFProvisioner represents the provisioners configured in the terraform output
@@ -83,6 +83,11 @@ type ServiceAccount struct {
 type Disk struct {
 	Type string `json:"disk_type"`
 	Size int    `json:"disk_size_gb"`
+}
+
+// AdvancedMachineFeatures represents advanced machine features associated to an instance template resource
+type AdvancedMachineFeatures struct {
+	EnableNestedVirtualization bool `json:"enable_nested_virtualization"`
 }
 
 // Trigger represents a trigger attributes of a GCP gcloud resource

--- a/anthos-bm-gcp-terraform/test/util/tf_module.go
+++ b/anthos-bm-gcp-terraform/test/util/tf_module.go
@@ -36,29 +36,30 @@ type TFResource struct {
 // JSON output of terraform plan. Note that this is a union of all possible
 // values for any modules used in this script
 type TFValues struct {
-	Name              string           `json:"name"`
-	Index             string           `json:"index"`
-	Region            string           `json:"region"`
-	Zone              string           `json:"zone"`
-	AddressType       string           `json:"address_type"`
-	InstanceTemplate  string           `json:"source_instance_template"`
-	FileName          string           `json:"filename"`
-	FilePermissions   string           `json:"file_permission"`
-	DirPermissions    string           `json:"directory_permission"`
-	CryptoAlgorithm   string           `json:"algorithm"`
-	Content           string           `json:"content"`
-	Project           string           `json:"project"`
-	ImageFamily       string           `json:"family"`
-	MachineType       string           `json:"machine_type"`
-	MinCPUPlatform    string           `json:"min_cpu_platform"`
-	Service           string           `json:"service"`
-	CanIPForward      bool             `json:"can_ip_forward"`
-	Trigger           Trigger          `json:"triggers"`
-	Tags              []string         `json:"tags"`
-	Disk              []Disk           `json:"disk"`
-	ServiceAccount    []ServiceAccount `json:"service_account"`
-	NetworkInterfaces []Interface      `json:"network_interface"`
-	Gpu               *Gpu             `json:"gpu"`
+	Name                       string           `json:"name"`
+	Index                      string           `json:"index"`
+	Region                     string           `json:"region"`
+	Zone                       string           `json:"zone"`
+	AddressType                string           `json:"address_type"`
+	InstanceTemplate           string           `json:"source_instance_template"`
+	FileName                   string           `json:"filename"`
+	FilePermissions            string           `json:"file_permission"`
+	DirPermissions             string           `json:"directory_permission"`
+	CryptoAlgorithm            string           `json:"algorithm"`
+	Content                    string           `json:"content"`
+	Project                    string           `json:"project"`
+	ImageFamily                string           `json:"family"`
+	MachineType                string           `json:"machine_type"`
+	MinCPUPlatform             string           `json:"min_cpu_platform"`
+	EnableNestedVirtualization bool             `json:"enable_nested_virtualization"`
+	Service                    string           `json:"service"`
+	CanIPForward               bool             `json:"can_ip_forward"`
+	Trigger                    Trigger          `json:"triggers"`
+	Tags                       []string         `json:"tags"`
+	Disk                       []Disk           `json:"disk"`
+	ServiceAccount             []ServiceAccount `json:"service_account"`
+	NetworkInterfaces          []Interface      `json:"network_interface"`
+	Gpu                        *Gpu             `json:"gpu"`
 }
 
 // TFProvisioner represents the provisioners configured in the terraform output

--- a/anthos-bm-gcp-terraform/test/validation/main_test_validation.go
+++ b/anthos-bm-gcp-terraform/test/validation/main_test_validation.go
@@ -325,6 +325,13 @@ func ValidateVariablesInMain(goTester *testing.T, tfPlan *util.MainModulePlan) {
 		"Variable not found in plan: min_cpu_platform",
 	)
 
+	// verify plan has enable_nested_virtualization input variable
+	assert.NotNil(
+		goTester,
+		tfPlan.Variables.EnableNestedVirtualization,
+		"Variable not found in plan: enable_nested_virtualization",
+	)
+
 	// verify plan has tags input variable
 	assert.NotNil(
 		goTester,
@@ -507,6 +514,14 @@ func ValidateVariableValuesInMain(goTester *testing.T, tfPlan *util.MainModulePl
 		"Variable does not match in plan: min_cpu_platform.",
 	)
 
+	// verify input variable enable_nested_virtualization in plan matches
+	assert.Equal(
+		goTester,
+		(*vars)["enable_nested_virtualization"],
+		tfPlan.Variables.EnableNestedVirtualization.Value,
+		"Variable does not match in plan: enable_nested_virtualization.",
+	)
+
 	// verify input variable tags in plan matches every tag in the list
 	for _, tag := range tfPlan.Variables.Tags.Value {
 		assert.Contains(
@@ -654,6 +669,12 @@ func ValidateInstanceTemplateModule(goTester *testing.T, module *util.TFModule, 
 				(*vars)["min_cpu_platform"],
 				resource.Values.MinCPUPlatform,
 				fmt.Sprintf("Invalid value for resources[%d].values.min_cpu_platform in the instance_template child module", idx),
+			)
+			assert.Equal(
+				goTester,
+				(*vars)["enable_nested_virtualization"],
+				resource.Values.EnableNestedVirtualization,
+				fmt.Sprintf("Invalid value for resources[%d].values.enable_nested_virtualization in the instance_template child module", idx),
 			)
 			assert.Equal(
 				goTester,

--- a/anthos-bm-gcp-terraform/test/validation/main_test_validation.go
+++ b/anthos-bm-gcp-terraform/test/validation/main_test_validation.go
@@ -325,13 +325,6 @@ func ValidateVariablesInMain(goTester *testing.T, tfPlan *util.MainModulePlan) {
 		"Variable not found in plan: min_cpu_platform",
 	)
 
-	// verify plan has enable_nested_virtualization input variable
-	assert.NotNil(
-		goTester,
-		tfPlan.Variables.EnableNestedVirtualization,
-		"Variable not found in plan: enable_nested_virtualization",
-	)
-
 	// verify plan has tags input variable
 	assert.NotNil(
 		goTester,
@@ -514,14 +507,6 @@ func ValidateVariableValuesInMain(goTester *testing.T, tfPlan *util.MainModulePl
 		"Variable does not match in plan: min_cpu_platform.",
 	)
 
-	// verify input variable enable_nested_virtualization in plan matches
-	assert.Equal(
-		goTester,
-		(*vars)["enable_nested_virtualization"],
-		tfPlan.Variables.EnableNestedVirtualization.Value,
-		"Variable does not match in plan: enable_nested_virtualization.",
-	)
-
 	// verify input variable tags in plan matches every tag in the list
 	for _, tag := range tfPlan.Variables.Tags.Value {
 		assert.Contains(
@@ -637,6 +622,11 @@ func ValidateInstanceTemplateModule(goTester *testing.T, module *util.TFModule, 
 			)
 			assert.True(
 				goTester,
+				resource.Values.AdvancedMachineFeatures[0].EnableNestedVirtualization,
+				fmt.Sprintf("Invalid value for resources[%d].values.advacned_machine_features[0].enable_nested_virtualization in the instance_template child module", idx),
+			)
+			assert.True(
+				goTester,
 				resource.Values.CanIPForward,
 				fmt.Sprintf("Invalid value for resources[%d].values.can_ip_forward in the instance_template child module", idx),
 			)
@@ -669,12 +659,6 @@ func ValidateInstanceTemplateModule(goTester *testing.T, module *util.TFModule, 
 				(*vars)["min_cpu_platform"],
 				resource.Values.MinCPUPlatform,
 				fmt.Sprintf("Invalid value for resources[%d].values.min_cpu_platform in the instance_template child module", idx),
-			)
-			assert.Equal(
-				goTester,
-				(*vars)["enable_nested_virtualization"],
-				resource.Values.EnableNestedVirtualization,
-				fmt.Sprintf("Invalid value for resources[%d].values.enable_nested_virtualization in the instance_template child module", idx),
 			)
 			assert.Equal(
 				goTester,

--- a/anthos-bm-gcp-terraform/test/validation/main_test_validation.go
+++ b/anthos-bm-gcp-terraform/test/validation/main_test_validation.go
@@ -325,6 +325,13 @@ func ValidateVariablesInMain(goTester *testing.T, tfPlan *util.MainModulePlan) {
 		"Variable not found in plan: min_cpu_platform",
 	)
 
+	// verify plan has enable_nested_virtualization input variable
+	assert.NotNil(
+		goTester,
+		tfPlan.Variables.EnableNestedVirtualization.Value,
+		"Variable not found in plan: enable_nested_virtualization",
+	)
+
 	// verify plan has tags input variable
 	assert.NotNil(
 		goTester,
@@ -507,6 +514,14 @@ func ValidateVariableValuesInMain(goTester *testing.T, tfPlan *util.MainModulePl
 		"Variable does not match in plan: min_cpu_platform.",
 	)
 
+	// verify input variable enable_nested_virtualization in plan matches
+	assert.Equal(
+		goTester,
+		(*vars)["enable_nested_virtualization"],
+		tfPlan.Variables.EnableNestedVirtualization.Value,
+		"Variable does not match in plan: enable_nested_virtualization.",
+	)
+
 	// verify input variable tags in plan matches every tag in the list
 	for _, tag := range tfPlan.Variables.Tags.Value {
 		assert.Contains(
@@ -622,11 +637,6 @@ func ValidateInstanceTemplateModule(goTester *testing.T, module *util.TFModule, 
 			)
 			assert.True(
 				goTester,
-				resource.Values.AdvancedMachineFeatures[0].EnableNestedVirtualization,
-				fmt.Sprintf("Invalid value for resources[%d].values.advacned_machine_features[0].enable_nested_virtualization in the instance_template child module", idx),
-			)
-			assert.True(
-				goTester,
 				resource.Values.CanIPForward,
 				fmt.Sprintf("Invalid value for resources[%d].values.can_ip_forward in the instance_template child module", idx),
 			)
@@ -659,6 +669,12 @@ func ValidateInstanceTemplateModule(goTester *testing.T, module *util.TFModule, 
 				(*vars)["min_cpu_platform"],
 				resource.Values.MinCPUPlatform,
 				fmt.Sprintf("Invalid value for resources[%d].values.min_cpu_platform in the instance_template child module", idx),
+			)
+			assert.Equal(
+				goTester,
+				(*vars)["enable_nested_virtualization"],
+				fmt.Sprint(resource.Values.AdvancedMachineFeatures[0].EnableNestedVirtualization),
+				fmt.Sprintf("Invalid value for resources[%d].values.advanced_machine_features[0].enable_nested_virtualization in the instance_template child module", idx),
 			)
 			assert.Equal(
 				goTester,

--- a/anthos-bm-gcp-terraform/variables.tf
+++ b/anthos-bm-gcp-terraform/variables.tf
@@ -56,6 +56,12 @@ variable "min_cpu_platform" {
   default     = "Intel Haswell"
 }
 
+variable "enable_nested_virtualization" {
+  description = "Enable nested virtualization on the Compute Engine VMs are to be scheduled"
+  type        = string
+  default     = "true"
+}
+
 variable "machine_type" {
   description = "Google Cloud machine type to use when provisioning the Compute Engine VMs"
   type        = string

--- a/anthos-bm-gcp-terraform/variables.tf
+++ b/anthos-bm-gcp-terraform/variables.tf
@@ -56,12 +56,6 @@ variable "min_cpu_platform" {
   default     = "Intel Haswell"
 }
 
-variable "enable_nested_virtualization" {
-  description = "Enable nested virtualiztion on the Compute Engines VMs"
-  type        = string
-  default     = "true"
-}
-
 variable "machine_type" {
   description = "Google Cloud machine type to use when provisioning the Compute Engine VMs"
   type        = string

--- a/anthos-bm-gcp-terraform/variables.tf
+++ b/anthos-bm-gcp-terraform/variables.tf
@@ -56,6 +56,12 @@ variable "min_cpu_platform" {
   default     = "Intel Haswell"
 }
 
+variable "enable_nested_virtualization" {
+  description = "Enable nested virtualiztion on the Compute Engines VMs"
+  type        = string
+  default     = "true"
+}
+
 variable "machine_type" {
   description = "Google Cloud machine type to use when provisioning the Compute Engine VMs"
   type        = string


### PR DESCRIPTION
### Fixes #211 

#### Description
- Enable nested virtualization support for better performance using [Anthos VM Runtime](https://cloud.google.com/anthos/clusters/docs/bare-metal/latest/how-to/vm-workloads) on [Anthos Baremetal on GCE](https://github.com/GoogleCloudPlatform/anthos-samples/tree/main/anthos-bm-gcp-terraform).

#### Change summary
- Adds `enable_nested_virtualization` to instance_template
- Add `var.enable_nested_virtualization` to `variable.tf`, default is enabled.
- Adds tests for `enable_nested_virtualization` and `var.enable_nested_virtualization`