### PR TITLE
chore: Update Codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,4 +10,4 @@
 /aws-logging-monitoring/          @GoogleCloudPlatform/onyx-gke-observability
 /attached-logging-monitoring/     @GoogleCloudPlatform/onyx-gke-observability
 /anthos-multi-cloud/		      @GoogleCloudPlatform/anthos-multicloud
-/.github/                         @googleapis/cdpe-devplat
+/.github/                         @GoogleCloudPlatform/cdpe-devplat

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,4 +10,3 @@
 /aws-logging-monitoring/          @GoogleCloudPlatform/onyx-gke-observability
 /attached-logging-monitoring/     @GoogleCloudPlatform/onyx-gke-observability
 /anthos-multi-cloud/		      @GoogleCloudPlatform/anthos-multicloud
-/.github/                         @GoogleCloudPlatform/cdpe-devplat


### PR DESCRIPTION
### Fixes n/a
Error in the CODEOWNERS file

#### Description
- I noticed that there was no existing group `googleapis/cdpe-devplat`, saw that it was incorrectly written instead of being `@GoogleCloudPlatform/cdpe-devplat`

#### Change summary
~Changed~ Removed  `googleapis/cdpe-devplat` ~to @GoogleCloudPlatform/cdpe-devplat~

#### Related PRs/Issues
n/a!


