### PR TITLE
feat: [anthos-bm-gcp-terraform] auto remove gke hub membership

### DIFF
--- a/anthos-bm-gcp-terraform/docs/variables.md
+++ b/anthos-bm-gcp-terraform/docs/variables.md
@@ -44,6 +44,7 @@ terraform-docs markdown table \
 | <a name="module_create_service_accounts"></a> [create\_service\_accounts](#module\_create\_service\_accounts) | terraform-google-modules/service-accounts/google | ~> 4.0 |
 | <a name="module_enable_google_apis_primary"></a> [enable\_google\_apis\_primary](#module\_enable\_google\_apis\_primary) | terraform-google-modules/project-factory/google//modules/project_services | 12.0.0 |
 | <a name="module_enable_google_apis_secondary"></a> [enable\_google\_apis\_secondary](#module\_enable\_google\_apis\_secondary) | terraform-google-modules/project-factory/google//modules/project_services | 12.0.0 |
+| <a name="module_gke_hub_membership"></a> [gke\_hub\_membership](#module\_gke\_hub\_membership) | terraform-google-modules/gcloud/google | ~>3.1.1 |
 | <a name="module_init_hosts"></a> [init\_hosts](#module\_init\_hosts) | ./modules/init | n/a |
 | <a name="module_install_abm"></a> [install\_abm](#module\_install\_abm) | ./modules/install | n/a |
 | <a name="module_instance_template"></a> [instance\_template](#module\_instance\_template) | terraform-google-modules/vm/google//modules/instance_template | ~> 7.6.0 |

--- a/anthos-bm-gcp-terraform/main.tf
+++ b/anthos-bm-gcp-terraform/main.tf
@@ -335,3 +335,11 @@ module "install_abm" {
   publicIp             = local.publicIps[local.admin_vm_hostnames[0]]
   ssh_private_key_file = format(local.private_key_file_path_template, local.admin_vm_hostnames[0])
 }
+
+module "gke_hub_membership" {
+  source   = "terraform-google-modules/gcloud/google"
+  version  = "~>3.1.1"
+  platform = "linux"
+  # Delete the hub membership created by 'bmctl create cluster'
+  destroy_cmd_body = "container hub memberships delete --quiet --project ${var.project_id} ${var.abm_cluster_id} --verbosity=none || true"
+}

--- a/anthos-bm-gcp-terraform/test/unit/main_custom_mode_test.go
+++ b/anthos-bm-gcp-terraform/test/unit/main_custom_mode_test.go
@@ -95,7 +95,8 @@ func TestUnit_MainScript_InstallMode(goTester *testing.T) {
 			strings.HasSuffix(moduleAddress, "vm_hosts") ||
 			strings.HasSuffix(moduleAddress, "service_accounts") ||
 			strings.Contains(moduleAddress, "google_apis") ||
-			strings.Contains(moduleAddress, "init_hosts") {
+			strings.Contains(moduleAddress, "init_hosts")  ||
+			strings.Contains(moduleAddress, "gke_hub_membership") {
 			continue
 		} else if strings.Contains(moduleAddress, "install_abm") {
 			installAbmModule = append(installAbmModule, childModule)
@@ -211,7 +212,8 @@ func TestUnit_MainScript_ManualLB(goTester *testing.T) {
 			strings.HasSuffix(moduleAddress, "vm_hosts") ||
 			strings.HasSuffix(moduleAddress, "service_accounts") ||
 			strings.Contains(moduleAddress, "google_apis") ||
-			strings.Contains(moduleAddress, "init_hosts") {
+			strings.Contains(moduleAddress, "init_hosts") ||
+			strings.Contains(moduleAddress, "gke_hub_membership") {
 			continue
 		} else if strings.HasSuffix(moduleAddress, "configure_ingress_lb[0]") {
 			ingressLBModule = append(ingressLBModule, childModule)

--- a/anthos-bm-gcp-terraform/test/unit/main_test.go
+++ b/anthos-bm-gcp-terraform/test/unit/main_test.go
@@ -180,6 +180,7 @@ func TestUnit_MainScript(goTester *testing.T) {
 	var initHostsModules []util.TFModule
 	var ingressLBModule []util.TFModule
 	var controlplaneLBModule []util.TFModule
+	var gkeHubMembership []util.TFModule
 
 	for _, childModule := range terraformPlan.PlannedValues.RootModule.ChildModules {
 		moduleAddress := childModule.ModuleAddress
@@ -197,6 +198,8 @@ func TestUnit_MainScript(goTester *testing.T) {
 			ingressLBModule = append(ingressLBModule, childModule)
 		} else if strings.HasSuffix(moduleAddress, "configure_controlplane_lb[0]") {
 			controlplaneLBModule = append(controlplaneLBModule, childModule)
+		} else if strings.HasSuffix(moduleAddress, "gke_hub_membership") {
+			gkeHubMembership = append(gkeHubMembership, childModule)
 		} else {
 			goTester.Errorf("Unexpected module with address [%s] at planned_values.root_module.child_modules", moduleAddress)
 		}
@@ -243,6 +246,12 @@ func TestUnit_MainScript(goTester *testing.T) {
 		controlplaneLBModule,
 		0,
 		"Unexpected number of child modules with address type configure_controlplane_lb at planned_values.root_module.child_modules",
+	)
+	assert.Len(
+		goTester,
+		gkeHubMembership,
+		1,
+		"Unexpected number of child modules with address type gke_hub_membership at planned_values.root_module.child_modules",
 	)
 
 	// validate the instance template module


### PR DESCRIPTION
### Fixes #261

#### Description
- For install modes automatically deletes the GKE hub membership during the TF destroy.