### PR TITLE
feat: Allow setting multiple admin users.

### DIFF
--- a/anthos-multi-cloud/AWS/main.tf
+++ b/anthos-multi-cloud/AWS/main.tf
@@ -63,7 +63,7 @@ module "anthos_cluster" {
   cluster_version                 = coalesce(var.cluster_version, module.gcp_data.latest_version)
   database_encryption_kms_key_arn = module.kms.database_encryption_kms_key_arn
   iam_instance_profile            = module.iam.cp_instance_profile_id
-  admin_user                      = var.admin_user
+  admin_users                     = var.admin_users
   vpc_id                          = module.vpc.aws_vpc_id
   role_arn                        = module.iam.api_role_arn
   subnet_ids                      = [module.vpc.aws_cp_subnet_id_1, module.vpc.aws_cp_subnet_id_2, module.vpc.aws_cp_subnet_id_3]

--- a/anthos-multi-cloud/AWS/modules/anthos_cluster/main.tf
+++ b/anthos-multi-cloud/AWS/modules/anthos_cluster/main.tf
@@ -33,8 +33,12 @@ resource "google_container_aws_cluster" "this" {
   location    = var.location
   name        = var.anthos_prefix
   authorization {
-    admin_users {
-      username = var.admin_user
+    dynamic "admin_users" {
+      for_each = var.admin_users
+
+      content {
+        username = admin_users.value
+      }
     }
   }
   control_plane {

--- a/anthos-multi-cloud/AWS/modules/anthos_cluster/variables.tf
+++ b/anthos-multi-cloud/AWS/modules/anthos_cluster/variables.tf
@@ -30,7 +30,8 @@ variable "pod_address_cidr_blocks" {
 variable "service_address_cidr_blocks" {
   default = ["10.1.0.0/16"]
 }
-variable "admin_user" {
+variable "admin_users" {
+  type = list(string)
 }
 variable "vpc_id" {
 }

--- a/anthos-multi-cloud/AWS/provider.tf
+++ b/anthos-multi-cloud/AWS/provider.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.5.0"
+      version = ">= 4.14.0"
     }
   }
 }

--- a/anthos-multi-cloud/AWS/terraform.tfvars
+++ b/anthos-multi-cloud/AWS/terraform.tfvars
@@ -1,5 +1,5 @@
 gcp_project_id          = "xxx-xxx-xxx"
-admin_user              = "example@example.com"
+admin_users             = ["user1@domain.com", "user2@domain.com"]
 name_prefix             = "aws-cluster"
 node_pool_instance_type = "t3.medium"
 cluster_version         = "1.21.6-gke.1500"

--- a/anthos-multi-cloud/AWS/variables.tf
+++ b/anthos-multi-cloud/AWS/variables.tf
@@ -26,9 +26,9 @@ variable "name_prefix" {
 
 # This step sets up the default RBAC policy in your cluster for a Google
 # user so you can login after cluster creation
-variable "admin_user" {
+variable "admin_users" {
   description = "User to get default Admin RBAC"
-  type        = string
+  type        = list(string)
 }
 
 variable "cluster_version" {


### PR DESCRIPTION
### Fixes ISSUE_NO_HERE
- If you still haven't done yet, then please do create an issue in the repository before opening this PR

#### Description
- Allow setting multiple admin users for Anthos clusters on AWS.

#### Change summary
- List of changes done in this PR

#### Related PRs/Issues
- List any related PRs and Issues


