### PR TITLE
feat: [anthos-vmruntime] use service selector with 

### DIFF
--- a/anthos-vmruntime/README.md
+++ b/anthos-vmruntime/README.md
@@ -359,32 +359,21 @@ Annotations:  <none>
 Events:       <none>
 ```
 
-Note that there are erros indicating that the `api-server-svc` was not found.
+Note that there are errors indicating that the `api-server-svc` was not found.
 This is because we deleted the resources created by default in [an earlier step](#cleanup-the-resources-created-by-default-in-the-installation-guide).
 We will have to re-create this `Service` pointing to the
 `VirtualMachineInstance`. This way, we can get the `Ingress` working once again
 and reach the sample application inside the VM via the `Ingress` LB IP.
 
 Copy the [`pos-service.yaml`](pos-service.yaml) file into the admin workstation
-VM. Then, update the file to include the IP address of the VM as a service
-`Endpoint`. Finally apply the changes to the cluster.
+and apply to the cluster.
 
 ```sh
-# you should have the pos-service.yaml copied into the admin workstation
-
-# retrieve the IP address of the virtual machine we created
-export VM_IP=$(kubectl get vmi/pos-vm -o jsonpath='{.status.interfaces[0].ipAddress}')
-
-# update the pos-service.yaml with the virtual machine's IP address
-sed -i "s/VM_IP/${VM_IP}/g" pos-service.yaml
-
-# apply the changes to the Anthos on bare metal cluster
 kubectl apply -f pos-service.yaml
 ```
 ```sh
 # expected output
 service/api-server-svc created
-endpoints/api-server-svc created
 ```
 ---
 ### Access the VM workload via the `Ingress Loadbalancer`

--- a/anthos-vmruntime/pos-service.yaml
+++ b/anthos-vmruntime/pos-service.yaml
@@ -18,20 +18,10 @@ kind: Service
 metadata:
   name: api-server-svc
 spec:
+  selector:
+    vm.cluster.gke.io/vm-name: pos-vm
   ports:
   - protocol: TCP
     port: 8080
     targetPort: 8081
 # [END anthosbaremetal_anthos_vmruntime_pos_service_service_api_server_svc]
----
-# [START anthosbaremetal_anthos_vmruntime_pos_service_endpoints_api_server_svc]
-apiVersion: v1
-kind: Endpoints
-metadata:
-  name: api-server-svc
-subsets:
-  - addresses:
-      - ip: VM_IP
-    ports:
-      - port: 8081
-# [END anthosbaremetal_anthos_vmruntime_pos_service_endpoints_api_server_svc]


### PR DESCRIPTION
Use service selector with the anthos-vmruntime VM, this also enables live migration of the VM.