### PR TITLE
feat: [anthos-bm-gcp-terraform] add back AppArmor

### DIFF
--- a/anthos-bm-gcp-terraform/resources/init_vm.sh
+++ b/anthos-bm-gcp-terraform/resources/init_vm.sh
@@ -42,7 +42,6 @@ function __main__ () {
 
   __install_deps__
   __setup_vxlan__
-  __disable_apparmour__
   __setup_admin_host__
 
   echo "[+] Successfully completed initialization of host $HOSTNAME"
@@ -107,25 +106,6 @@ function __update_bridge_entries__ () {
       echo "Skipping bridge forwarding entry setup for ip [$ip]"
     fi
   done
-  __print_separator__
-}
-
-##############################################################################
-# Disable apparmour service on the host. Anthos clusters on bare metal does
-# not support apparmor
-##############################################################################
-function __disable_apparmour__ () {
-  echo "Stopping apparmor system service"
-  systemctl stop apparmor.service
-  __check_exit_status__ $? \
-    "[+] Successfully stopped apparmor service" \
-    "[-] Failed to stop apparmor service. Check for failures on [systemctl stop apparmor.service] in ~/$LOG_FILE"
-
-  systemctl disable apparmor.service
-  __check_exit_status__ $? \
-    "[+] Successfully disabled apparmor service" \
-    "[-] Failed to disable apparmor service. Check for failures on [systemctl disable apparmor.service] in ~/$LOG_FILE"
-
   __print_separator__
 }
 


### PR DESCRIPTION
### Fixes #283 
- Removes disable AppArmor as it is [supported](https://cloud.google.com/anthos/clusters/docs/bare-metal/latest/installing/configure-os/ubuntu#before_you_begin) in Anthos clusters on bare metal v1.8.2+.