### PR TITLE
fix: AWS route_table names interpolating variables

### DIFF
--- a/anthos-multi-cloud/AWS/modules/vpc/main.tf
+++ b/anthos-multi-cloud/AWS/modules/vpc/main.tf
@@ -98,7 +98,7 @@ resource "aws_route_table" "public" {
   vpc_id = aws_vpc.this.id
 
   tags = {
-    Name = "${local.vpc_name}-public-[count.index]"
+    Name = "${local.vpc_name}-public-${count.index}"
   }
 }
 
@@ -148,7 +148,7 @@ resource "aws_route_table" "private" {
   count  = local.az_count
   vpc_id = aws_vpc.this.id
   tags = {
-    Name = "${local.vpc_name}-private{[count.index]}"
+    Name = "${local.vpc_name}-private-${count.index}"
   }
 }
 


### PR DESCRIPTION
### Fixes #287 

#### Description
- Any aws_route_table resources created should have the `count.index` interpolated in the `Name` tag rather than read in as a string
- In a vpc called my-vpc, this change will create route tables called `my-vpc-public-1`, `my-vpc-public-2`, `my-vpc-public-3` rather than 3 subnets all called `my-vpc-public-[count.index]`.

#### Change summary
- Corrected tag definition of aws_route_table resources to correctly interpolate the value of `count.index`

#### Related PRs/Issues
- List any related PRs and Issues


