### PR TITLE
fix: [anthos-multi-cloud] Missing AWS IAM role policies for CP

### DIFF
--- a/anthos-multi-cloud/AWS/modules/iam/main.tf
+++ b/anthos-multi-cloud/AWS/modules/iam/main.tf
@@ -77,6 +77,7 @@ data "aws_iam_policy_document" "api_policy_document" {
       "ec2:RunInstances",
       "ec2:RevokeSecurityGroupIngress",
       "ec2:RevokeSecurityGroupEgress",
+      "ec2:GetConsoleOutput",
       "ec2:DescribeVpcs",
       "ec2:DescribeVolumes",
       "ec2:DescribeSubnets",


### PR DESCRIPTION
According to https://cloud.google.com/anthos/clusters/docs/multi-cloud/aws/how-to/create-aws-iam-roles

AWS: CP nodes need `ec2:GetConsoleOutput` IAM permission

### Fixes ISSUE_NO_HERE
- If you still haven't done yet, then please do create an issue in the repository before opening this PR

#### Description
- CP Instances wont be successfully provisioned due to missing IAM permission

#### Change summary
- Add missing AWS IAM permission to `API_ROLE`

#### Related PRs/Issues
- List any related PRs and Issues


