### PR TITLE
Fix method of obtaining service account token

### DIFF
--- a/anthos-bm-edge-deployment/roles/abm-login-token/tasks/get-login-token.yaml
+++ b/anthos-bm-edge-deployment/roles/abm-login-token/tasks/get-login-token.yaml
@@ -17,7 +17,20 @@
 - name: "Get login token for console"
   shell: |
     set -o pipefail
-    export SECRET_NAME=$(kubectl get serviceaccount console-cluster-reader -o jsonpath='{$.secrets[0].name}' -n default)
+    export SECRET_NAME=console-cluster-reader-token
+    kubectl apply -f - << __EOF__
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: "${SECRET_NAME}"
+      annotations:
+        kubernetes.io/service-account.name: console-cluster-reader
+    type: kubernetes.io/service-account-token
+    __EOF__
+    until [[ $(kubectl get -o=jsonpath="{.data.token}" "secret/${SECRET_NAME}") ]]; do
+      echo "waiting for token..." >&2;
+      sleep 1;
+    done
     export KSA_TOKEN=$(kubectl get secret ${SECRET_NAME} -o jsonpath='{$.data.token}' -n default | base64 --decode)
     export TOKEN_NAME="{{ cluster_name }}-k8s-token"
     echo $KSA_TOKEN

--- a/anthos-bm-gcp-terraform/resources/login.sh
+++ b/anthos-bm-gcp-terraform/resources/login.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-KSA_NAME=edga-sa
+KSA_NAME=edge-sa
 
 echo "-------------------------------------------------------------------"
 echo "💡 Creating Kubernetes ClusterRole: cloud-console-reader"
@@ -47,11 +47,27 @@ kubectl create clusterrolebinding edge-sa-view-binding \
 kubectl create clusterrolebinding edge-sa-console-reader-binding \
   --clusterrole cloud-console-reader --serviceaccount default:${KSA_NAME}
 kubectl create clusterrolebinding another-binding \
-  --clusterrole cluster-admin --serviceaccount default:edga-sa
+  --clusterrole cluster-admin --serviceaccount default:${KSA_NAME}
 
 echo "-------------------------------------------------------------------"
-echo "💡 Retreiving Kubernetes Service Account Token"
-SECRET_NAME=$(kubectl get serviceaccount edga-sa -o jsonpath='{$.secrets[0].name}')
+echo "💡 Retrieving Kubernetes Service Account Token"
+SECRET_NAME=${KSA_NAME}-token
+
+kubectl apply -f - << __EOF__
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "${SECRET_NAME}"
+  annotations:
+    kubernetes.io/service-account.name: "${KSA_NAME}"
+type: kubernetes.io/service-account-token
+__EOF__
+
+until [[ $(kubectl get -o=jsonpath="{.data.token}" "secret/${SECRET_NAME}") ]]; do
+  echo "waiting for token..." >&2;
+  sleep 1;
+done
+
 TOKEN=$(kubectl get secret "${SECRET_NAME}" -o jsonpath='{$.data.token}' | base64 --decode)
 
 echo ""

--- a/anthos-bm-openstack-terraform/resources/abm_cluster_login.sh
+++ b/anthos-bm-openstack-terraform/resources/abm_cluster_login.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # [START anthosbaremetal_resources_abm_cluster_login]
-KSA_NAME=edga-sa
+KSA_NAME=edge-sa
 
 echo "-------------------------------------------------------------------"
 echo "💡 Creating Kubernetes ClusterRole: cloud-console-reader"
@@ -48,11 +48,27 @@ kubectl create clusterrolebinding edge-sa-view-binding \
 kubectl create clusterrolebinding edge-sa-console-reader-binding \
   --clusterrole cloud-console-reader --serviceaccount default:${KSA_NAME}
 kubectl create clusterrolebinding another-binding \
-  --clusterrole cluster-admin --serviceaccount default:edga-sa
+  --clusterrole cluster-admin --serviceaccount default:${KSA_NAME}
 
 echo "-------------------------------------------------------------------"
-echo "💡 Retreiving Kubernetes Service Account Token"
-SECRET_NAME=$(kubectl get serviceaccount edga-sa -o jsonpath='{$.secrets[0].name}')
+echo "💡 Retrieving Kubernetes Service Account Token"
+SECRET_NAME=${KSA_NAME}-token
+
+kubectl apply -f - << __EOF__
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "${SECRET_NAME}"
+  annotations:
+    kubernetes.io/service-account.name: "${KSA_NAME}"
+type: kubernetes.io/service-account-token
+__EOF__
+
+until [[ $(kubectl get -o=jsonpath="{.data.token}" "secret/${SECRET_NAME}") ]]; do 
+  echo "waiting for token..." >&2;
+  sleep 1;
+done
+
 TOKEN=$(kubectl get secret ${SECRET_NAME} -o jsonpath='{$.data.token}' | base64 --decode)
 
 echo ""


### PR DESCRIPTION
Fixes #306

#### Description

The .secrets field within service accounts is only for listing secrets
to be mounted into pods, not for extracting secrets for other uses.
There is no guarantee the first item in the list will be a token secret.

In 1.24+, this field is not populated by default.

#### Change summary
Adapt instructions from https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-service-account-api-token to obtain a token

cc @zshihang