### PR TITLE
fix: Changed storageclass name

### DIFF
--- a/anthos-bm-gcp-terraform/resources/templates/anthos_gce_cluster.tpl
+++ b/anthos-bm-gcp-terraform/resources/templates/anthos_gce_cluster.tpl
@@ -56,7 +56,7 @@ spec:
     lvpShare:
       numPVUnderSharedPath: 5
       path: /mnt/localpv-share
-      storageClassName: standard
+      storageClassName: local-shared
 ---
 apiVersion: baremetal.cluster.gke.io/v1
 kind: NodePool

--- a/anthos-bm-gcp-terraform/resources/templates/manuallb_cluster.tpl
+++ b/anthos-bm-gcp-terraform/resources/templates/manuallb_cluster.tpl
@@ -52,7 +52,7 @@ spec:
     lvpShare:
       numPVUnderSharedPath: 5
       path: /mnt/localpv-share
-      storageClassName: standard
+      storageClassName: local-shared
 ---
 apiVersion: baremetal.cluster.gke.io/v1
 kind: NodePool

--- a/anthos-bm-openstack-terraform/resources/abm_cluster.yaml.tpl
+++ b/anthos-bm-openstack-terraform/resources/abm_cluster.yaml.tpl
@@ -51,7 +51,7 @@ spec:
     lvpShare:
       numPVUnderSharedPath: 5
       path: /mnt/localpv-share
-      storageClassName: standard
+      storageClassName: local-shared
   nodeAccess:
     loginUser: abm
 

--- a/anthos-vmruntime/README.md
+++ b/anthos-vmruntime/README.md
@@ -158,7 +158,7 @@ create the VM using `kubectl apply -f pos-vm.yaml`.
 ```sh
 kubectl virt create vm pos-vm \
 --boot-disk-size=80Gi \
---boot-disk-storage-class=standard \
+--boot-disk-storage-class=local-shared \
 --cpu=2 \
 --image=https://storage.googleapis.com/abm-vm-images/ubuntu-2004-pos.qcow2 \
 --memory=4Gi

--- a/anthos-vmruntime/README.md
+++ b/anthos-vmruntime/README.md
@@ -158,7 +158,6 @@ create the VM using `kubectl apply -f pos-vm.yaml`.
 ```sh
 kubectl virt create vm pos-vm \
 --boot-disk-size=80Gi \
---boot-disk-storage-class=local-shared \
 --cpu=2 \
 --image=https://storage.googleapis.com/abm-vm-images/ubuntu-2004-pos.qcow2 \
 --memory=4Gi

--- a/anthos-vmruntime/pos-vm.yaml
+++ b/anthos-vmruntime/pos-vm.yaml
@@ -26,7 +26,7 @@ spec:
     resources:
       requests:
         storage: 80Gi
-    storageClassName: standard
+    storageClassName: local-shared
   source:
     http:
       url: https://storage.googleapis.com/abm-vm-images/ubuntu-2004-pos.qcow2


### PR DESCRIPTION
### Fixes https://github.com/GoogleCloudPlatform/anthos-samples/issues/270

#### Description
- All resources besides the anthos-bm-gcp-terraform template had 'local-shared' as the `storageClassName`.

#### Change summary
- Changed the template to have `storageClassName: local-shared` 

#### Related PRs/Issues
n/a


