### PR TITLE
cleanup: use the pos-ci project image

### DIFF
--- a/anthos-vmruntime/README.md
+++ b/anthos-vmruntime/README.md
@@ -158,10 +158,9 @@ create the VM using `kubectl apply -f pos-vm.yaml`.
 ```sh
 kubectl virt create vm pos-vm \
 --boot-disk-size=80Gi \
---boot-disk-storage-class=local-shared \
+--memory=4Gi \
 --cpu=2 \
---image=https://storage.googleapis.com/abm-vm-images/ubuntu-2004-pos.qcow2 \
---memory=4Gi
+--image=https://storage.googleapis.com/pos-vm-images/pos-vm.qcow2
 ```
 
 ```sh


### PR DESCRIPTION
### Fixes N/A

#### Description
- Point the A4VM guide to use the VM image from the point-of-sale-ci project instead of the test proejct shabir-pos

#### Change summary
- Update README

#### Related PRs/Issues
- NA
