### PR TITLE
feat: add KMS keys permission examples

### DIFF
--- a/anthos-multi-cloud/AWS/modules/anthos_cluster/main.tf
+++ b/anthos-multi-cloud/AWS/modules/anthos_cluster/main.tf
@@ -42,7 +42,7 @@ resource "google_container_aws_cluster" "this" {
     }
   }
   control_plane {
-    iam_instance_profile = var.iam_instance_profile
+    iam_instance_profile = var.control_plane_iam_instance_profile
     instance_type        = var.control_plane_instance_type
     subnet_ids           = var.subnet_ids
     tags = {
@@ -53,7 +53,7 @@ resource "google_container_aws_cluster" "this" {
       role_arn = var.role_arn
     }
     config_encryption {
-      kms_key_arn = var.database_encryption_kms_key_arn
+      kms_key_arn = var.control_plane_config_encryption_kms_key_arn
     }
     database_encryption {
       kms_key_arn = var.database_encryption_kms_key_arn
@@ -62,13 +62,13 @@ resource "google_container_aws_cluster" "this" {
       size_gib    = 30
       volume_type = "GP3"
       iops        = 3000
-      kms_key_arn = var.volume_kms_key_arn
+      kms_key_arn = var.control_plane_main_volume_encryption_kms_key_arn
     }
     root_volume {
       size_gib    = 30
       volume_type = "GP3"
       iops        = 3000
-      kms_key_arn = var.volume_kms_key_arn
+      kms_key_arn = var.control_plane_root_volume_encryption_kms_key_arn
     }
   }
   networking {
@@ -100,15 +100,15 @@ resource "google_container_aws_node_pool" "this" {
   }
   config {
     config_encryption {
-      kms_key_arn = var.database_encryption_kms_key_arn
+      kms_key_arn = var.node_pool_config_encryption_kms_key_arn
     }
     instance_type        = var.node_pool_instance_type
-    iam_instance_profile = var.iam_instance_profile
+    iam_instance_profile = var.node_pool_iam_instance_profile
     root_volume {
       size_gib    = 30
       volume_type = "GP3"
       iops        = 3000
-      kms_key_arn = var.volume_kms_key_arn
+      kms_key_arn = var.node_pool_root_volume_encryption_kms_key_arn
     }
     tags = {
       "Name" : "${var.anthos_prefix}-nodepool"

--- a/anthos-multi-cloud/AWS/modules/anthos_cluster/variables.tf
+++ b/anthos-multi-cloud/AWS/modules/anthos_cluster/variables.tf
@@ -20,9 +20,9 @@ variable "aws_region" {
 }
 variable "cluster_version" {
 }
-variable "database_encryption_kms_key_arn" {
+variable "control_plane_iam_instance_profile" {
 }
-variable "iam_instance_profile" {
+variable "node_pool_iam_instance_profile" {
 }
 variable "pod_address_cidr_blocks" {
   default = ["10.2.0.0/16"]
@@ -37,8 +37,17 @@ variable "vpc_id" {
 }
 variable "subnet_ids" {
 }
-variable "volume_kms_key_arn" {
-  default = null
+variable "database_encryption_kms_key_arn" {
+}
+variable "control_plane_config_encryption_kms_key_arn" {
+}
+variable "control_plane_root_volume_encryption_kms_key_arn" {
+}
+variable "control_plane_main_volume_encryption_kms_key_arn" {
+}
+variable "node_pool_config_encryption_kms_key_arn" {
+}
+variable "node_pool_root_volume_encryption_kms_key_arn" {
 }
 variable "role_arn" {
 }

--- a/anthos-multi-cloud/AWS/modules/iam/main.tf
+++ b/anthos-multi-cloud/AWS/modules/iam/main.tf
@@ -55,8 +55,6 @@ data "aws_iam_policy_document" "api_policy_document" {
   statement {
     effect = "Allow"
     actions = [
-      "kms:Encrypt",
-      "kms:DescribeKey",
       "iam:CreateServiceLinkedRole",
       "iam:PassRole",
       "elasticloadbalancing:DescribeTargetHealth",
@@ -106,6 +104,36 @@ data "aws_iam_policy_document" "api_policy_document" {
       "autoscaling:CreateAutoScalingGroup"
     ]
     resources = ["*"]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:DescribeKey",
+    ]
+    resources = [
+      "arn:aws:kms:*:*:key/*",
+    ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+    ]
+    resources = [var.cp_config_kms_arn]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+    ]
+    resources = [var.np_config_kms_arn]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:GenerateDataKeyWithoutPlaintext",
+    ]
+    resources = [var.cp_main_volume_kms_arn]
   }
 }
 resource "aws_iam_policy" "api_policy" {
@@ -215,10 +243,29 @@ data "aws_iam_policy_document" "cp_policy_document" {
   statement {
     effect = "Allow"
     actions = [
+      "kms:Decrypt",
       "kms:Encrypt",
-      "kms:Decrypt"
     ]
     resources = [var.db_kms_arn]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+    ]
+    resources = [var.cp_config_kms_arn]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:CreateGrant",
+    ]
+    resources = [var.cp_main_volume_kms_arn]
+    condition {
+      test     = "Bool"
+      variable = "kms:GrantIsForAWSResource"
+      values   = [true]
+    }
   }
 }
 resource "aws_iam_policy" "cp_policy" {
@@ -262,20 +309,9 @@ data "aws_iam_policy_document" "np_policy_document" {
   statement {
     effect = "Allow"
     actions = [
-      "autoscaling:DescribeAutoScalingGroups",
-      "ec2:AttachNetworkInterface",
-      "ec2:DescribeInstances",
-      "ec2:DescribeTags",
+      "kms:Decrypt",
     ]
-    resources = ["*"]
-  }
-  statement {
-    effect = "Allow"
-    actions = [
-      "kms:Encrypt",
-      "kms:Decrypt"
-    ]
-    resources = [var.db_kms_arn]
+    resources = [var.np_config_kms_arn]
   }
 }
 resource "aws_iam_policy" "np_policy" {

--- a/anthos-multi-cloud/AWS/modules/iam/variables.tf
+++ b/anthos-multi-cloud/AWS/modules/iam/variables.tf
@@ -28,3 +28,18 @@ variable "db_kms_arn" {
   description = "DB KMS ARN"
   type        = string
 }
+
+variable "cp_main_volume_kms_arn" {
+  description = "Control Plane Main Volume KMS ARN"
+  type        = string
+}
+
+variable "cp_config_kms_arn" {
+  description = "Control Plane Configuration KMS ARN"
+  type        = string
+}
+
+variable "np_config_kms_arn" {
+  description = "Node Pool Configuration KMS ARN"
+  type        = string
+}

--- a/anthos-multi-cloud/AWS/modules/kms/main.tf
+++ b/anthos-multi-cloud/AWS/modules/kms/main.tf
@@ -56,7 +56,7 @@ resource "aws_kms_alias" "control_plane_main_volume_encryption_kms_key_alias" {
 
 resource "aws_kms_key" "control_plane_root_volume_encryption_kms_key" {
   description = "${var.anthos_prefix} AWS Control Plane Root Volume Encryption KMS Key"
-  policy = data.aws_iam_policy_document.root_volume_encryption_policy_document.json
+  policy      = data.aws_iam_policy_document.root_volume_encryption_policy_document.json
 }
 
 resource "aws_kms_alias" "control_plane_root_volume_encryption_kms_key_alias" {
@@ -119,7 +119,7 @@ data "aws_iam_policy_document" "root_volume_encryption_policy_document" {
   }
   // Allow access by root account.
   statement {
-    effect = "Allow"
+    effect  = "Allow"
     actions = ["kms:*"]
     principals {
       type        = "AWS"
@@ -140,7 +140,7 @@ resource "aws_kms_alias" "node_pool_config_encryption_kms_key_alias" {
 
 resource "aws_kms_key" "node_pool_root_volume_encryption_kms_key" {
   description = "${var.anthos_prefix} AWS Node Pool Root Volume Encryption KMS Key"
-  policy = data.aws_iam_policy_document.root_volume_encryption_policy_document.json
+  policy      = data.aws_iam_policy_document.root_volume_encryption_policy_document.json
 }
 
 resource "aws_kms_alias" "node_pool_root_volume_encryption_kms_key_alias" {

--- a/anthos-multi-cloud/AWS/modules/kms/main.tf
+++ b/anthos-multi-cloud/AWS/modules/kms/main.tf
@@ -29,10 +29,121 @@ data "aws_caller_identity" "current" {}
 
 resource "aws_kms_key" "database_encryption_kms_key" {
   description = "${var.anthos_prefix} AWS Database Encryption KMS Key"
-
 }
 
 resource "aws_kms_alias" "database_encryption_kms_key_alias" {
   target_key_id = aws_kms_key.database_encryption_kms_key.arn
-  name          = "alias/anthos-${var.anthos_prefix}-database-encryption-key"
+  name          = "alias/anthos-${var.anthos_prefix}-database-key"
+}
+
+resource "aws_kms_key" "control_plane_config_encryption_kms_key" {
+  description = "${var.anthos_prefix} AWS Control Plane Configuration Encryption KMS Key"
+}
+
+resource "aws_kms_alias" "control_plane_config_encryption_kms_key_alias" {
+  target_key_id = aws_kms_key.control_plane_config_encryption_kms_key.arn
+  name          = "alias/anthos-${var.anthos_prefix}-cp-config-key"
+}
+
+resource "aws_kms_key" "control_plane_main_volume_encryption_kms_key" {
+  description = "${var.anthos_prefix} AWS Control Plane Main Volume Encryption KMS Key"
+}
+
+resource "aws_kms_alias" "control_plane_main_volume_encryption_kms_key_alias" {
+  target_key_id = aws_kms_key.control_plane_main_volume_encryption_kms_key.arn
+  name          = "alias/anthos-${var.anthos_prefix}-cp-main-volume-key"
+}
+
+resource "aws_kms_key" "control_plane_root_volume_encryption_kms_key" {
+  description = "${var.anthos_prefix} AWS Control Plane Root Volume Encryption KMS Key"
+  policy = data.aws_iam_policy_document.root_volume_encryption_policy_document.json
+}
+
+resource "aws_kms_alias" "control_plane_root_volume_encryption_kms_key_alias" {
+  target_key_id = aws_kms_key.control_plane_root_volume_encryption_kms_key.arn
+  name          = "alias/anthos-${var.anthos_prefix}-cp-root-volume-key"
+}
+
+data "aws_iam_policy_document" "root_volume_encryption_policy_document" {
+  // Allow access by AWSServiceRoleForAutoScaling.
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:CreateGrant",
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"]
+    }
+    resources = [
+      "arn:aws:kms:${var.aws_region}:${data.aws_caller_identity.current.account_id}:key/*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:CallerAccount"
+      values   = ["${data.aws_caller_identity.current.account_id}"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["ec2.${var.aws_region}.amazonaws.com"]
+    }
+    condition {
+      test     = "Bool"
+      variable = "kms:GrantIsForAWSResource"
+      values   = [true]
+    }
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:GenerateDataKeyWithoutPlaintext",
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"]
+    }
+    resources = [
+      "arn:aws:kms:${var.aws_region}:${data.aws_caller_identity.current.account_id}:key/*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:CallerAccount"
+      values   = ["${data.aws_caller_identity.current.account_id}"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["ec2.${var.aws_region}.amazonaws.com"]
+    }
+  }
+  // Allow access by root account.
+  statement {
+    effect = "Allow"
+    actions = ["kms:*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    resources = ["*"]
+  }
+}
+
+resource "aws_kms_key" "node_pool_config_encryption_kms_key" {
+  description = "${var.anthos_prefix} AWS Node Pool Configuration Encryption KMS Key"
+}
+
+resource "aws_kms_alias" "node_pool_config_encryption_kms_key_alias" {
+  target_key_id = aws_kms_key.node_pool_config_encryption_kms_key.arn
+  name          = "alias/anthos-${var.anthos_prefix}-np-config-key"
+}
+
+resource "aws_kms_key" "node_pool_root_volume_encryption_kms_key" {
+  description = "${var.anthos_prefix} AWS Node Pool Root Volume Encryption KMS Key"
+  policy = data.aws_iam_policy_document.root_volume_encryption_policy_document.json
+}
+
+resource "aws_kms_alias" "node_pool_root_volume_encryption_kms_key_alias" {
+  target_key_id = aws_kms_key.node_pool_root_volume_encryption_kms_key.arn
+  name          = "alias/anthos-${var.anthos_prefix}-np-root-volume-key"
 }

--- a/anthos-multi-cloud/AWS/modules/kms/outputs.tf
+++ b/anthos-multi-cloud/AWS/modules/kms/outputs.tf
@@ -18,3 +18,28 @@ output "database_encryption_kms_key_arn" {
   description = "ARN of the actuated KMS key resource for cluster secret encryption"
   value       = aws_kms_key.database_encryption_kms_key.arn
 }
+
+output "control_plane_config_encryption_kms_key_arn" {
+  description = "ARN of the actuated KMS key resource for cluster control plane user data encryption"
+  value       = aws_kms_key.control_plane_config_encryption_kms_key.arn
+}
+
+output "control_plane_main_volume_encryption_kms_key_arn" {
+  description = "ARN of the actuated KMS key resource for cluster control plane main volume encryption"
+  value       = aws_kms_key.control_plane_main_volume_encryption_kms_key.arn
+}
+
+output "control_plane_root_volume_encryption_kms_key_arn" {
+  description = "ARN of the actuated KMS key resource for cluster control plane root volume encryption"
+  value       = aws_kms_key.control_plane_root_volume_encryption_kms_key.arn
+}
+
+output "node_pool_config_encryption_kms_key_arn" {
+  description = "ARN of the actuated KMS key resource for cluster node pool user data encryption"
+  value       = aws_kms_key.node_pool_config_encryption_kms_key.arn
+}
+
+output "node_pool_root_volume_encryption_kms_key_arn" {
+  description = "ARN of the actuated KMS key resource for cluster node pool root volume encryption"
+  value       = aws_kms_key.node_pool_root_volume_encryption_kms_key.arn
+}

--- a/anthos-multi-cloud/AWS/modules/kms/variables.tf
+++ b/anthos-multi-cloud/AWS/modules/kms/variables.tf
@@ -18,3 +18,8 @@ variable "anthos_prefix" {
   description = "anthos name prefix"
   type        = string
 }
+
+variable "aws_region" {
+  description = "AWS Region to use for KMS"
+  type        = string
+}


### PR DESCRIPTION
#### Description
- Create different AWS KMS keys and provides examples on how to set permissions to create a k8s cluster


#### Change summary
- Added 5 new KMS keys on different purpose based on https://cloud.google.com/anthos/clusters/docs/multi-cloud/aws/how-to/create-aws-kms-key
- Pass arns of the keys to module iam to set the iam policy
- Update module `anthos_cluster` to use these kms keys
- Separate iam_instance_profile into control_plane_iam_instance_profile & node_pool_iam_instance_profile for module `anthos_cluster` to reflect different permission requirement

#### Related PRs/Issues
- N/A


