### PR TITLE
fix: Use AMC commands instead of Hub commands to get kubeconfig

### DIFF
--- a/anthos-multi-cloud/AWS/README.md
+++ b/anthos-multi-cloud/AWS/README.md
@@ -111,7 +111,7 @@ gcloud components update
  1. Login to the Cluster
 
    ``` bash
-   gcloud container hub memberships get-credentials [cluster name]
+   gcloud container aws clusters get-credentials [cluster name]
    kubectl get nodes
    ```
 ## Extra: Connect Anthos Configuration Management

--- a/anthos-multi-cloud/AWS/outputs.tf
+++ b/anthos-multi-cloud/AWS/outputs.tf
@@ -20,6 +20,6 @@ output "cluster_name" {
 }
 output "message" {
   description = "Connect Instructions"
-  value       = "To connect to your cluster issue the command: gcloud container hub memberships get-credentials ${local.name_prefix}"
+  value       = "To connect to your cluster issue the command: gcloud container aws clusters get-credentials ${local.name_prefix}"
 
 }

--- a/anthos-multi-cloud/Azure/README.md
+++ b/anthos-multi-cloud/Azure/README.md
@@ -124,7 +124,7 @@ After the cluster has been installed it will show up in the [Kubernetes Engine p
  1. Login to the Cluster
 
    ```bash
-   gcloud container hub memberships get-credentials [cluster name]
+   gcloud container azure clusters get-credentials [cluster name]
    kubectl get nodes
    ```
 ## Extra: Connect Anthos Configuration Management

--- a/anthos-multi-cloud/Azure/outputs.tf
+++ b/anthos-multi-cloud/Azure/outputs.tf
@@ -34,5 +34,5 @@ output "cluster_resource_group" {
 
 output "message" {
   description = "Connect Instructions"
-  value       = "To connect to your cluster issue the command:\n gcloud container hub memberships get-credentials ${local.name_prefix}"
+  value       = "To connect to your cluster issue the command:\n gcloud container azure clusters get-credentials ${local.name_prefix}"
 }


### PR DESCRIPTION

#### Description
- Use AMC commands as listed at
  - https://cloud.google.com/anthos/clusters/docs/multi-cloud/aws/how-to/connect-and-authenticate-to-your-cluster
  - https://cloud.google.com/anthos/clusters/docs/multi-cloud/azure/how-to/connect-and-authenticate-to-your-cluster

#### Change summary
- Replace `gcloud container hub memberships get-credentials` with
  - `gcloud container aws clusters get-credentials`
  - `gcloud container azure clusters get-credentials`

#### Related PRs/Issues
- N/A


