### PR TITLE
fix: replaced cluster-1 with variable

### DIFF
--- a/anthos-bm-gcp-terraform/docs/manuallb_install.md
+++ b/anthos-bm-gcp-terraform/docs/manuallb_install.md
@@ -241,7 +241,7 @@ To verify your deployment, complete the following steps:
     gcloud compute scp \
         --project=${PROJECT} \
         --zone=${ZONE} \
-        tfadmin@cluster1-abm-ws0-001:${KUBECONFIG_PATH_IN_ADMIN_VM} \
+        tfadmin@${CLUSTER_ID}-abm-ws0-001:${KUBECONFIG_PATH_IN_ADMIN_VM} \
         ${KUBECONFIG_PATH_IN_LOCAL_WORKSTATION}
     ```
 


### PR DESCRIPTION
### Fixes https://github.com/GoogleCloudPlatform/anthos-samples/issues/282


#### Description
- Fixed the hardcoded cluster name in gcloud command

#### Change summary
- removed `cluster1` with `${CLUTER_ID}`

#### Related PRs/Issues
https://github.com/GoogleCloudPlatform/anthos-samples/issues/282


