### PR TITLE
[nettest] Uses all images within anthos-baremetal-release

### DIFF
--- a/anthos-bm-utils/abm-nettest/nettest.yaml
+++ b/anthos-bm-utils/abm-nettest/nettest.yaml
@@ -212,7 +212,7 @@ spec:
     image: gcr.io/anthos-baremetal-release/nettest:v0.2.0__linux_amd64
     imagePullPolicy: IfNotPresent
     command: ["/nettest"]
-    args: ["-v=0", "-alsologtostderr", "-engine_config=/cfg/engine.yaml"]
+    args: ["-v=2", "-alsologtostderr", "-engine_config=/cfg/engine.yaml"]
     ports:
     - name: http
       containerPort: 8999

--- a/anthos-bm-utils/abm-nettest/nettest.yaml
+++ b/anthos-bm-utils/abm-nettest/nettest.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: echoserver
-        image: gcr.io/google_containers/echoserver:1.4
+        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.1__linux_amd64
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -59,7 +59,7 @@ spec:
       hostNetwork: true
       containers:
       - name: echoserver
-        image: gcr.io/google_containers/echoserver:1.4
+        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.1__linux_amd64
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -169,7 +169,7 @@ data:
               namespace: nettest
               name: echoserver-hostnetwork
     - createCloudprobers:
-        cloudproberImage: gcr.io/anthos-baremetal-release/cloudprober:release-0.11.6-gke.5
+        cloudproberImage: gcr.io/anthos-baremetal-release/cloudprober:release-0.11.7-gke.28
         probeFromCPNodes: true
     - waitFor:
         duration: 5m
@@ -209,7 +209,7 @@ metadata:
 spec:
   containers:
   - name: nettest
-    image: gcr.io/anthos-baremetal-release/nettest:v0.2.0__linux_amd64
+    image: gcr.io/anthos-baremetal-release/nettest:v0.3.1__linux_amd64
     imagePullPolicy: IfNotPresent
     command: ["/nettest"]
     args: ["-v=2", "-alsologtostderr", "-engine_config=/cfg/engine.yaml"]
@@ -240,4 +240,3 @@ spec:
       name: nettest-prometheus
   serviceAccountName: nettest
   restartPolicy: Never
-

--- a/anthos-bm-utils/abm-nettest/nettest.yaml
+++ b/anthos-bm-utils/abm-nettest/nettest.yaml
@@ -164,7 +164,7 @@ data:
             endpoint:
               namespace: nettest
               name: echoserver-non-hostnetwork
-          vms:
+          nodes:
             endpoint:
               namespace: nettest
               name: echoserver-hostnetwork

--- a/anthos-bm-utils/abm-nettest/nettest_rhel.yaml
+++ b/anthos-bm-utils/abm-nettest/nettest_rhel.yaml
@@ -212,7 +212,7 @@ spec:
     image: gcr.io/anthos-baremetal-release/nettest:v0.2.0__linux_amd64
     imagePullPolicy: IfNotPresent
     command: ["/nettest"]
-    args: ["-v=0", "-alsologtostderr", "-engine_config=/cfg/engine.yaml"]
+    args: ["-v=2", "-alsologtostderr", "-engine_config=/cfg/engine.yaml"]
     ports:
     - name: http
       containerPort: 8999

--- a/anthos-bm-utils/abm-nettest/nettest_rhel.yaml
+++ b/anthos-bm-utils/abm-nettest/nettest_rhel.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: echoserver
-        image: gcr.io/google_containers/echoserver:1.4
+        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.1__linux_amd64
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -59,7 +59,7 @@ spec:
       hostNetwork: true
       containers:
       - name: echoserver
-        image: gcr.io/google_containers/echoserver:1.4
+        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.1__linux_amd64
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -169,7 +169,7 @@ data:
               namespace: nettest
               name: echoserver-hostnetwork
     - createCloudprobers:
-        cloudproberImage: gcr.io/anthos-baremetal-release/cloudprober:release-0.11.6-gke.5
+        cloudproberImage: gcr.io/anthos-baremetal-release/cloudprober:release-0.11.7-gke.28
         probeFromCPNodes: true
     - waitFor:
         duration: 5m
@@ -209,7 +209,7 @@ metadata:
 spec:
   containers:
   - name: nettest
-    image: gcr.io/anthos-baremetal-release/nettest:v0.2.0__linux_amd64
+    image: gcr.io/anthos-baremetal-release/nettest:v0.3.1__linux_amd64
     imagePullPolicy: IfNotPresent
     command: ["/nettest"]
     args: ["-v=2", "-alsologtostderr", "-engine_config=/cfg/engine.yaml"]

--- a/anthos-bm-utils/abm-nettest/nettest_rhel.yaml
+++ b/anthos-bm-utils/abm-nettest/nettest_rhel.yaml
@@ -164,7 +164,7 @@ data:
             endpoint:
               namespace: nettest
               name: echoserver-non-hostnetwork
-          vms:
+        nodes:
             endpoint:
               namespace: nettest
               name: echoserver-hostnetwork


### PR DESCRIPTION
### Fixes #350 

#### Description
- Replaces gcr.io/google-containers/echoserver with gcr.io/anthos-baremetal-release/simplehttpserver
- Use `node` instead `vm` in the probe names


