### PR TITLE
chore: updates nettest version to 0.3.2

### DIFF
--- a/anthos-bm-utils/abm-nettest/nettest.yaml
+++ b/anthos-bm-utils/abm-nettest/nettest.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: echoserver
-        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.1__linux_amd64
+        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.2__linux_amd64
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -59,7 +59,7 @@ spec:
       hostNetwork: true
       containers:
       - name: echoserver
-        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.1__linux_amd64
+        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.2__linux_amd64
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -248,7 +248,7 @@ metadata:
 spec:
   containers:
   - name: nettest
-    image: gcr.io/anthos-baremetal-release/nettest:v0.3.1__linux_amd64
+    image: gcr.io/anthos-baremetal-release/nettest:v0.3.2__linux_amd64
     imagePullPolicy: IfNotPresent
     command: ["/nettest"]
     args: ["-v=2", "-alsologtostderr", "-engine_config=/cfg/engine.yaml"]

--- a/anthos-bm-utils/abm-nettest/nettest_rhel.yaml
+++ b/anthos-bm-utils/abm-nettest/nettest_rhel.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: echoserver
-        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.1__linux_amd64
+        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.2__linux_amd64
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -59,7 +59,7 @@ spec:
       hostNetwork: true
       containers:
       - name: echoserver
-        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.1__linux_amd64
+        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.2__linux_amd64
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -248,7 +248,7 @@ metadata:
 spec:
   containers:
   - name: nettest
-    image: gcr.io/anthos-baremetal-release/nettest:v0.3.1__linux_amd64
+    image: gcr.io/anthos-baremetal-release/nettest:v0.3.2__linux_amd64
     imagePullPolicy: IfNotPresent
     command: ["/nettest"]
     args: ["-v=2", "-alsologtostderr", "-engine_config=/cfg/engine.yaml"]


### PR DESCRIPTION
### Fixes #371 

#### Description
- Updates nettest version to 0.3.2, which fixes the issue where nettest cannot run on baremetal nodes.

