### PR TITLE
fix: prevent logmon to run on unsupported win node

### DIFF
--- a/attached-logging-monitoring/logging/aggregator.yaml
+++ b/attached-logging-monitoring/logging/aggregator.yaml
@@ -153,6 +153,8 @@ spec:
         managed-by: stackdriver
     spec:
       serviceAccountName: stackdriver-log-aggregator
+      nodeSelector:
+        kubernetes.io/os: linux
       containers:
       - name: stackdriver-log-aggregator
         image: gcr.io/stackdriver-agents/stackdriver-logging-agent:1.8.4

--- a/attached-logging-monitoring/logging/forwarder.yaml
+++ b/attached-logging-monitoring/logging/forwarder.yaml
@@ -76,6 +76,8 @@ spec:
         app: stackdriver-log-forwarder
         managed-by: stackdriver
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
       containers:
       - name: stackdriver-log-forwarder
         image: fluent/fluent-bit:1.6.4

--- a/attached-logging-monitoring/monitoring/prometheus.yaml
+++ b/attached-logging-monitoring/monitoring/prometheus.yaml
@@ -160,6 +160,8 @@ spec:
         fsGroup: 2000
         runAsUser: 1000
         runAsNonRoot: true
+      nodeSelector:
+        kubernetes.io/os: linux
       containers:
       - name: prometheus-server
         image: prom/prometheus:v2.18.1


### PR DESCRIPTION
### Fixes #386 

#### Description
- Added a linux OS nodeselctor on all logmon agents for attached cluster.

#### Related PRs/Issues
- also related to #6 which asks for a solution for Windows.


