### PR TITLE
feat: update anthos-vmruntime example for ABM 1.12

### DIFF
--- a/anthos-vmruntime/README.md
+++ b/anthos-vmruntime/README.md
@@ -153,7 +153,7 @@ directory.
 
 The following command uses the `virtctl` plugin of the `kubectl` CLI.
 Alternatively, you can also create the VM using **KRM** definitions in a yaml.
-The [/anthos-vmruntime/pos-vm.yaml](/pos-vm.yaml) is another way of expressing the creation of a
+The [/anthos-vmruntime/pos-vm.yaml](pos-vm.yaml) is another way of expressing the creation of a
 VM. Thus, you can also copy this yaml definition into the admin workstation and
 create the VM using `kubectl apply -f pos-vm.yaml`.
 

--- a/anthos-vmruntime/README.md
+++ b/anthos-vmruntime/README.md
@@ -101,7 +101,9 @@ using `kubectl apply -f vmruntime.yaml`.
 Validate that the `VMRuntime` is enabled.
 ```sh
 kubectl wait --for=jsonpath='{.status.ready}'=true --timeout=300s vmruntime vmruntime
+```
 
+```sh
 # expected output
 vmruntime.vm.cluster.gke.io/vmruntime condition met
 ```
@@ -178,18 +180,18 @@ Created gvm "pos-vm"
 ### Check the VM creation status
 
 Creation of the VM requires two resources to be created: `VirtualMachineDisk` and
-`VirtualMachine`. 
+`VirtualMachine`.
 
 - `VirtualMachineDisk` is the _persistent disk_ where the contents of the
 **VM image** is imported into and is made bootable from. The `VirtualMachineDisk`
 wraps around the `DataVolume` resource which can be used to monitor progress
 of the import.
 
-- `VirtualMachine` is the **VM template** created based off of the image. 
+- `VirtualMachine` is the **VM template** created based off of the image.
 Creation of a `VirtualMachine`, automatically triggers the creation of a
 `VirtualMachineInstance` resource which represents a _RUNNING_ instance of
 a VM. The `VirtualMachineDisk` is mounted into the `VirtualMachine` before the VM is
-booted up. 
+booted up.
 
 - Check the status of the `VirtualMachineDisk`.
     ```sh

--- a/anthos-vmruntime/README.md
+++ b/anthos-vmruntime/README.md
@@ -178,13 +178,18 @@ Created gvm "pos-vm"
 ### Check the VM creation status
 
 Creation of the VM requires two resources to be created: `VirtualMachineDisk` and
-`VirtualMachine`. `VirtualMachineDisk` is the _persistent disk_ where the
-contents of the **VM image** is imported into and is made bootable from.
-`VirtualMachine` is the **VM template** created based off of the image. The
-`VirtualMachineDisk` is mounted into the `VirtualMachine` before the VM is
-booted up. Creation of a `VirtualMachine`, automatically triggers the creation
-of a `VirtualMachineInstance` resource which represents a _RUNNING_ instance of
-a VM.
+`VirtualMachine`. 
+
+- `VirtualMachineDisk` is the _persistent disk_ where the contents of the
+**VM image** is imported into and is made bootable from. The `VirtualMachineDisk`
+wraps around the `DataVolume` resource which can be used to monitor progress
+of the import.
+
+- `VirtualMachine` is the **VM template** created based off of the image. 
+Creation of a `VirtualMachine`, automatically triggers the creation of a
+`VirtualMachineInstance` resource which represents a _RUNNING_ instance of
+a VM. The `VirtualMachineDisk` is mounted into the `VirtualMachine` before the VM is
+booted up. 
 
 - Check the status of the `VirtualMachineDisk`.
     ```sh

--- a/anthos-vmruntime/README.md
+++ b/anthos-vmruntime/README.md
@@ -100,10 +100,10 @@ using `kubectl apply -f vmruntime.yaml`.
 
 Validate that the `VMRuntime` is enabled.
 ```sh
-kubectl describe vmruntime vmruntime | grep Ready
+kubectl wait --for=jsonpath='{.status.ready}'=true --timeout=300s vmruntime vmruntime
 
 # expected output
-  Ready:                       true
+vmruntime.vm.cluster.gke.io/vmruntime condition met
 ```
 ---
 ###  Install the [`virtctl`](https://kubevirt.io/user-guide/operations/virtctl_client_tool/) plugin for `kubectl`
@@ -159,33 +159,42 @@ create the VM using `kubectl apply -f pos-vm.yaml`.
 kubectl virt create vm pos-vm \
 --boot-disk-size=80Gi \
 --memory=4Gi \
---cpu=2 \
+--vcpus=2 \
 --image=https://storage.googleapis.com/pos-vm-images/pos-vm.qcow2
 ```
 
 ```sh
 # expected output
-Constructing yaml for vm "pos-vm":
-Deployment yaml for vm "pos-vm" is saved to pos-vm.yaml.
-Apply yaml for vm "pos-vm"
-Creating boot DataVolume "pos-vm-boot-dv"
-Creating gvm "pos-vm"
+Constructing manifest for vm "pos-vm":
+Manifest for vm "pos-vm" is saved to /home/tfadmin/google-virtctl/pos-vm.yaml
+Applying manifest for vm "pos-vm"
+Created gvm "pos-vm"
 ```
 > **Note:** After you run `kubectl virt create vm pos-vm`, the CLI would have
 > created a yaml file named after the vm (`pos-vm.yaml`). You can inspect it to
-> see the definiton of the `VirtualMachine` and `DataVolume`.
+> see the definiton of the `VirtualMachine` and `VirtualMachineDisk`.
 
 ---
 ### Check the VM creation status
 
-Creation of the VM requires two resources to be created: `DataVolume` and
-`VirtualMachine`. `DataVolume` is the _persistent disk_ where the contents of
-the **VM image** is imported into and is made bootable from. `VirtualMachine` is
-the **VM template** created based off of the image. The `DataVolume` is mounted
-into the `VirtualMachine` before the VM is booted up. Creation of a
-`VirtualMachine`, automatically triggers the creation of a
-`VirtualMachineInstance` resource which represents a _RUNNING_ instance of a VM.
+Creation of the VM requires two resources to be created: `VirtualMachineDisk` and
+`VirtualMachine`. `VirtualMachineDisk` is the _persistent disk_ where the
+contents of the **VM image** is imported into and is made bootable from.
+`VirtualMachine` is the **VM template** created based off of the image. The
+`VirtualMachineDisk` is mounted into the `VirtualMachine` before the VM is
+booted up. Creation of a `VirtualMachine`, automatically triggers the creation
+of a `VirtualMachineInstance` resource which represents a _RUNNING_ instance of
+a VM.
 
+- Check the status of the `VirtualMachineDisk`.
+    ```sh
+    kubectl get VirtualMachineDisk
+    ```
+    ```sh
+    # expected output
+    NAME               AGE
+    pos-vm-boot-dv     8s
+    ```
 - Check the status of the `DataVolume`.
     ```sh
     # you can use dv and datavolume interchangeably
@@ -256,10 +265,10 @@ into the `VirtualMachine` before the VM is booted up. Creation of a
     NAME      AGE     PHASE     IP              NODENAME                      READY
     pos-vm    40m     Running   192.168.3.250   kubevirt-cluster-abm-w1-001   True
     ```
-- You may also use the `vm.cluster.gke.io/v1alpha1` API to get a concatanated
+- You may also use the `vm.cluster.gke.io/v1` API to get a concatenated
   update of the two resources above.
     ```sh
-    k get gvm
+    kubectl get gvm
 
     NAME      STATUS    AGE     IP
     pos-vm    Running   40m     192.168.3.250

--- a/anthos-vmruntime/pos-service.yaml
+++ b/anthos-vmruntime/pos-service.yaml
@@ -19,7 +19,7 @@ metadata:
   name: api-server-svc
 spec:
   selector:
-    vm.cluster.gke.io/vm-name: pos-vm
+    kubevirt/vm: pos-vm
   ports:
   - protocol: TCP
     port: 8080

--- a/anthos-vmruntime/pos-vm.yaml
+++ b/anthos-vmruntime/pos-vm.yaml
@@ -13,59 +13,36 @@
 # limitations under the License.
 
 # [START anthosbaremetal_anthos_vmruntime_pos_vm_datavolume_pos_vm_boot_dv]
-apiVersion: cdi.kubevirt.io/v1beta1
-kind: DataVolume
+apiVersion: vm.cluster.gke.io/v1
+kind: VirtualMachineDisk
 metadata:
-  creationTimestamp: null
   name: pos-vm-boot-dv
   namespace: default
 spec:
-  pvc:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 80Gi
-    storageClassName: local-shared
+  size: 80Gi
   source:
     http:
       url: https://storage.googleapis.com/pos-vm-images/pos-vm.qcow2
 # [END anthosbaremetal_anthos_vmruntime_pos_vm_datavolume_pos_vm_boot_dv]
 ---
 # [START anthosbaremetal_anthos_vmruntime_pos_vm_virtualmachine_pos_vm]
-apiVersion: vm.cluster.gke.io/v1alpha1
+apiVersion: vm.cluster.gke.io/v1
 kind: VirtualMachine
 metadata:
-  creationTimestamp: null
   name: pos-vm
   namespace: default
 spec:
-  compute: {}
-  disks: null
+  compute:
+    cpu:
+      vcpus: 2
+    memory:
+      capacity: 4Gi
+  disks:
+  - boot: true
+    driver: virtio
+    virtualMachineDiskName: pos-vm-boot-dv
   interfaces:
   - name: eth0
+    default: true
     networkName: pod-network
-  virtSpec:
-    template:
-      metadata:
-        creationTimestamp: null
-        labels:
-          kubevirt.io/vm: pos-vm
-      spec:
-        domain:
-          cpu:
-            cores: 2
-          devices:
-            disks:
-            - bootOrder: 1
-              disk:
-                bus: virtio
-              name: pos-vm-boot-dv
-          resources:
-            requests:
-              memory: 4Gi
-        volumes:
-        - dataVolume:
-            name: pos-vm-boot-dv
-          name: pos-vm-boot-dv
 # [END anthosbaremetal_anthos_vmruntime_pos_vm_virtualmachine_pos_vm]

--- a/anthos-vmruntime/pos-vm.yaml
+++ b/anthos-vmruntime/pos-vm.yaml
@@ -23,6 +23,7 @@ spec:
   source:
     http:
       url: https://storage.googleapis.com/pos-vm-images/pos-vm.qcow2
+  storageClassName: local-shared
 # [END anthosbaremetal_anthos_vmruntime_pos_vm_datavolume_pos_vm_boot_dv]
 ---
 # [START anthosbaremetal_anthos_vmruntime_pos_vm_virtualmachine_pos_vm]


### PR DESCRIPTION
### Fixes #420

#### Description
- Updates anthos-vmruntime for ABM 1.12

#### Change summary
anthos-vmruntime
- Cli `--cpu` is now `--vcpus`
- Updated expected output to 1.12 format
- Added `VirtualMachineDisk` cli example
- Updated .yaml files to VM Runtime v1 syntax
- Updated `vm.cluster.gke.io/vm-name` is now `kubevirt/vm`