### PR TITLE
chore: ypdate setup_and_install_abm.sh

### DIFF
--- a/anthos-bm-gcp-bash/setup_and_install_abm.sh
+++ b/anthos-bm-gcp-bash/setup_and_install_abm.sh
@@ -33,6 +33,7 @@ gcloud services enable \
     anthosaudit.googleapis.com \
     anthosgke.googleapis.com \
     cloudresourcemanager.googleapis.com \
+    connectgateway.googleapis.com \
     container.googleapis.com \
     gkeconnect.googleapis.com \
     gkehub.googleapis.com \


### PR DESCRIPTION
Enable connectgateway.googleapis.com so we can demonstrate `gcloud container fleet memberships get-credentials` in the tutorial.

### Fixes ISSUE_NO_HERE
- If you still haven't done yet, then please do create an issue in the repository before opening this PR

#### Description
- Brief description of the issue/purpose of this PR
- Include environment _(e.g: Linux/Ubuntu running terraform v14.10 etc)_ if relavant

#### Change summary
- List of changes done in this PR

#### Related PRs/Issues
- List any related PRs and Issues


