### PR TITLE
feat: update ABM version to 1.14.0

### DIFF
--- a/anthos-bm-gcp-bash/install_hybrid_cluster.sh
+++ b/anthos-bm-gcp-bash/install_hybrid_cluster.sh
@@ -182,7 +182,7 @@ curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s ht
 chmod +x kubectl
 mv kubectl /usr/local/sbin/
 mkdir baremetal && cd baremetal
-gsutil cp gs://anthos-baremetal-release/bmctl/1.13.1/linux-amd64/bmctl .
+gsutil cp gs://anthos-baremetal-release/bmctl/1.14.0/linux-amd64/bmctl .
 chmod a+x bmctl
 mv bmctl /usr/local/sbin/
 

--- a/anthos-bm-gcp-terraform/resources/init_vm.sh
+++ b/anthos-bm-gcp-terraform/resources/init_vm.sh
@@ -167,7 +167,7 @@ function __setup_kubctl__ () {
 ##############################################################################
 function __setup_bmctl__ () {
   mkdir baremetal && cd baremetal || return
-  gsutil cp gs://anthos-baremetal-release/bmctl/1.13.1/linux-amd64/bmctl .
+  gsutil cp gs://anthos-baremetal-release/bmctl/1.14.0/linux-amd64/bmctl .
   chmod a+x bmctl
   mv bmctl /usr/local/sbin/
   __check_exit_status__ $? \

--- a/anthos-bm-gcp-terraform/resources/templates/anthos_gce_cluster.tpl
+++ b/anthos-bm-gcp-terraform/resources/templates/anthos_gce_cluster.tpl
@@ -17,7 +17,7 @@ metadata:
   namespace: ${clusterId}-ns
 spec:
   type: hybrid
-  anthosBareMetalVersion: 1.13.1
+  anthosBareMetalVersion: 1.14.0
   gkeConnect:
     projectID: ${projectId}
   controlPlane:

--- a/anthos-bm-gcp-terraform/resources/templates/manuallb_cluster.tpl
+++ b/anthos-bm-gcp-terraform/resources/templates/manuallb_cluster.tpl
@@ -17,7 +17,7 @@ metadata:
   namespace: ${clusterId}-ns
 spec:
   type: hybrid
-  anthosBareMetalVersion: 1.13.1
+  anthosBareMetalVersion: 1.14.0
   gkeConnect:
     projectID: ${projectId}
   controlPlane:

--- a/anthos-bm-gcp-terraform/test/unit/main_test.go
+++ b/anthos-bm-gcp-terraform/test/unit/main_test.go
@@ -433,6 +433,7 @@ func TestUnit_MainScript_ValidateDefaults(goTester *testing.T) {
 		"anthosaudit.googleapis.com",
 		"opsconfigmonitoring.googleapis.com",
 		"file.googleapis.com",
+		"connectgateway.googleapis.com",
 	}
 
 	assert.Len(

--- a/anthos-bm-gcp-terraform/variables.tf
+++ b/anthos-bm-gcp-terraform/variables.tf
@@ -162,7 +162,8 @@ variable "secondary_apis" {
     "compute.googleapis.com",
     "anthosaudit.googleapis.com",
     "opsconfigmonitoring.googleapis.com",
-    "file.googleapis.com"
+    "file.googleapis.com",
+    "connectgateway.googleapis.com"
   ]
 }
 

--- a/anthos-bm-gcp-terraform/versions.tf
+++ b/anthos-bm-gcp-terraform/versions.tf
@@ -28,7 +28,7 @@ terraform {
   }
 
   provider_meta "google" {
-    # Anthos Bare metal version used in this release is 1.13.1
+    # Anthos Bare metal version used in this release is 1.14.0
     # See
     # - https://github.com/GoogleCloudPlatform/anthos-samples/blob/main/anthos-bm-gcp-terraform/resources/templates/anthos_gce_cluster.tpl#L20
     # - https://github.com/GoogleCloudPlatform/anthos-samples/blob/main/anthos-bm-gcp-terraform/resources/init_vm.sh#L180

--- a/test/integration/abm_gce_defaults_on_editor_project/abm_gce_editor_test.go
+++ b/test/integration/abm_gce_defaults_on_editor_project/abm_gce_editor_test.go
@@ -57,7 +57,7 @@ func TestABMEditor(t *testing.T) {
 		assert.NotContains(abmInstall, "[-]", "gce setup for abm installation should not have any failed stages")
 
 		bmctl := runSSHCmd(t, projectID, "root@cluster1-abm-ws0-001", "bmctl version")
-		assert.Contains(bmctl, "bmctl version: 1.13.1", "bmctl version should be 1.13.1")
+		assert.Contains(bmctl, "bmctl version: 1.14.0", "bmctl version should be 1.14.0")
 
 		docker := runSSHCmd(t, projectID, "root@cluster1-abm-ws0-001", "docker version")
 		dockerExpectedOP := []string{"Client: Docker Engine", "Server: Docker Engine", "API version", "Version", "linux/amd64"}


### PR DESCRIPTION
#### Description
- Update ABM version to 1.14.0

#### Change summary
- Update ABM version to 1.14.0
- Add `connectgateway.googleapis.com` API as that is now required by ABM: https://cloud.google.com/anthos/clusters/docs/bare-metal/latest/installing/configure-sa#enable_apis