### PR TITLE
cleanup: renovate skip anthos-bm-edge-deployment sample

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,8 @@
   ],
   "ignorePaths": [
     "**/anthos-multi-cloud/**",
-    "**/anthos-bm-openstack-terraform/**"
+    "**/anthos-bm-openstack-terraform/**",
+    "**/anthos-bm-edge-deployment/**"
   ],
   "prConcurrentLimit":5,
   "stabilityDays":7,


### PR DESCRIPTION
### Fixes

#### Description
- Renovate is continuously trying to increase versions of Ansible and other dependencies related to the [anthos-bm-edge-deployment](https://github.com/GoogleCloudPlatform/anthos-samples/tree/main/anthos-bm-edge-deployment) sample
- This sample is a mirror of an internal repo and should only be updated according to the internal repo changes
- Thus, setting up renovate to not include this sample in its scanning.

#### Change summary
- Add the directory path to the anthos-bm-edge-deployment sample in renovate configs

#### Related PRs/Issues
- N/A


