### PR TITLE
chore: add shell fail fast flag to the install_hybrid_cluster script

### DIFF
--- a/anthos-bm-gcp-bash/install_hybrid_cluster.sh
+++ b/anthos-bm-gcp-bash/install_hybrid_cluster.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -euo pipefail
+
 printf "✅ Using Project [%s] and Zone [%s].\n\n" "$PROJECT_ID" "$ZONE"
 
 # create the GCP Service Account to be used by Anthos on bare metal


### PR DESCRIPTION
### FixesN/A

#### Description
- This is related to PR #531 
- It updates one script to fail fast; but there is another one that needs the same change.
- The comment to update that also was not responded to
- So I merged it and openned the update myself

#### Change summary
- Update the `install_hybrid_cluster` script to have the fail fast shell flag

#### Related PRs/Issues
- https://github.com/GoogleCloudPlatform/anthos-samples/pull/531


