### PR TITLE
feat: [anthos-bm-gcp-terraform] parameterize ABM version

### DIFF
--- a/anthos-bm-gcp-terraform/main.tf
+++ b/anthos-bm-gcp-terraform/main.tf
@@ -256,6 +256,7 @@ resource "local_file" "cluster_yaml_bundledlb" {
     gcp_accounts    = var.gcp_login_accounts,
     controlPlaneIps = local.controlplane_vxlan_ips,
     workerNodeIps   = local.worker_vxlan_ips
+    abmVersion      = var.abm_version
   })
 }
 
@@ -339,6 +340,7 @@ resource "local_file" "init_args_file" {
     ingressNeg        = var.mode == "manuallb" ? module.configure_ingress_lb[0].neg_name : ""
     ingressLbIp       = var.mode == "manuallb" ? module.configure_ingress_lb[0].public_ip : ""
     nfsServer         = var.nfs_server
+    abmVersion        = var.abm_version
   })
 }
 

--- a/anthos-bm-gcp-terraform/main.tf
+++ b/anthos-bm-gcp-terraform/main.tf
@@ -278,6 +278,7 @@ resource "local_file" "cluster_yaml_manuallb" {
     workerNodeIps   = local.worker_internal_ips,
     controlPlaneVIP = module.configure_controlplane_lb[0].public_ip,
     ingressVIP      = module.configure_ingress_lb[0].public_ip
+    abmVersion      = var.abm_version
   })
 }
 

--- a/anthos-bm-gcp-terraform/outputs.tf
+++ b/anthos-bm-gcp-terraform/outputs.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+output "abm_version" {
+  description = "Version of Anthos Bare Metal"
+  value       = var.abm_version
+}
+
 output "admin_vm_ssh" {
   description = "Run the following command to provision the anthos cluster."
   value = var.mode != "setup" ? null : join("\n", [

--- a/anthos-bm-gcp-terraform/resources/init_vm.sh
+++ b/anthos-bm-gcp-terraform/resources/init_vm.sh
@@ -168,7 +168,7 @@ function __setup_kubctl__ () {
 ##############################################################################
 function __setup_bmctl__ () {
   mkdir baremetal && cd baremetal || return
-  gsutil cp gs://anthos-baremetal-release/bmctl/$ABM_VERSION/linux-amd64/bmctl .
+  gsutil cp "gs://anthos-baremetal-release/bmctl/$ABM_VERSION/linux-amd64/bmctl" .
   chmod a+x bmctl
   mv bmctl /usr/local/sbin/
   __check_exit_status__ $? \

--- a/anthos-bm-gcp-terraform/resources/init_vm.sh
+++ b/anthos-bm-gcp-terraform/resources/init_vm.sh
@@ -30,6 +30,7 @@ VM_INTERNAL_IPS=$(cut -d "=" -f2- <<< "$(grep < init.vars VM_INTERNAL_IPS)")
 LOG_FILE=$(cut -d "=" -f2- <<< "$(grep < init.vars LOG_FILE)")
 DEFAULT_IFACE=$(ip link | awk -F: '$0 !~ "lo|vir|wl|^[^0-9]"{print $2;getline}' | xargs)
 NFS_SERVER=$(cut -d "=" -f2- <<< "$(grep < init.vars NFS_SERVER)")
+ABM_VERSION=$(cut -d "=" -f2- <<< "$(grep < init.vars ABM_VERSION)")
 
 DATE=$(date)
 HOSTNAME=$(hostname)
@@ -167,7 +168,7 @@ function __setup_kubctl__ () {
 ##############################################################################
 function __setup_bmctl__ () {
   mkdir baremetal && cd baremetal || return
-  gsutil cp gs://anthos-baremetal-release/bmctl/1.14.0/linux-amd64/bmctl .
+  gsutil cp gs://anthos-baremetal-release/bmctl/$ABM_VERSION/linux-amd64/bmctl .
   chmod a+x bmctl
   mv bmctl /usr/local/sbin/
   __check_exit_status__ $? \

--- a/anthos-bm-gcp-terraform/resources/templates/anthos_gce_cluster.tpl
+++ b/anthos-bm-gcp-terraform/resources/templates/anthos_gce_cluster.tpl
@@ -17,7 +17,7 @@ metadata:
   namespace: ${clusterId}-ns
 spec:
   type: hybrid
-  anthosBareMetalVersion: 1.14.0
+  anthosBareMetalVersion: ${abmVersion}
   gkeConnect:
     projectID: ${projectId}
   controlPlane:

--- a/anthos-bm-gcp-terraform/resources/templates/init.vars.tpl
+++ b/anthos-bm-gcp-terraform/resources/templates/init.vars.tpl
@@ -14,3 +14,4 @@ INGRESS_NEG=${ingressNeg}
 INGRESS_LB_IP=${ingressLbIp}
 INSTALL_MODE=${installMode}
 NFS_SERVER=${nfsServer}
+ABM_VERSION=${abmVersion}

--- a/anthos-bm-gcp-terraform/resources/templates/manuallb_cluster.tpl
+++ b/anthos-bm-gcp-terraform/resources/templates/manuallb_cluster.tpl
@@ -17,7 +17,7 @@ metadata:
   namespace: ${clusterId}-ns
 spec:
   type: hybrid
-  anthosBareMetalVersion: 1.14.0
+  anthosBareMetalVersion: ${abmVersion}
   gkeConnect:
     projectID: ${projectId}
   controlPlane:

--- a/anthos-bm-gcp-terraform/variables.tf
+++ b/anthos-bm-gcp-terraform/variables.tf
@@ -205,6 +205,12 @@ variable "mode" {
   }
 }
 
+variable "abm_version" {
+  description = "Version of Anthos Bare Metal"
+  type        = string
+  default     = "1.14.1"
+}
+
 variable "as_sub_module" {
   description = "This script is being run as a sub module; thus output extra variables"
   type        = bool

--- a/anthos-bm-gcp-terraform/versions.tf
+++ b/anthos-bm-gcp-terraform/versions.tf
@@ -28,10 +28,6 @@ terraform {
   }
 
   provider_meta "google" {
-    # Anthos Bare metal version used in this release is 1.14.0
-    # See
-    # - https://github.com/GoogleCloudPlatform/anthos-samples/blob/main/anthos-bm-gcp-terraform/resources/templates/anthos_gce_cluster.tpl#L20
-    # - https://github.com/GoogleCloudPlatform/anthos-samples/blob/main/anthos-bm-gcp-terraform/resources/init_vm.sh#L180
     module_name = "anthos-samples/terraform/anthos-bm-terraform:gce/v0.13.1"
   }
 

--- a/test/fixtures/abm_gce_defaults_on_editor_project/outputs.tf
+++ b/test/fixtures/abm_gce_defaults_on_editor_project/outputs.tf
@@ -18,3 +18,7 @@
 output "project_id" {
   value = var.editor_project_id
 }
+
+output "abm_version" {
+  value = module.anthos_bm_gcp.abm_version
+}

--- a/test/integration/abm_gce_defaults_on_editor_project/abm_gce_editor_test.go
+++ b/test/integration/abm_gce_defaults_on_editor_project/abm_gce_editor_test.go
@@ -29,6 +29,7 @@ func TestABMEditor(t *testing.T) {
 	abm.DefineVerify(func(assert *assert.Assertions) {
 		abm.DefaultVerify(assert)
 		projectID := abm.GetStringOutput("project_id")
+		abmVersion := abm.GetStringOutput("abm_version")
 
 		// pre run ssh command so that ssh-keygen can run
 		runSSHCmd(t, projectID, "tfadmin@cluster1-abm-ws0-001", "ls")
@@ -57,7 +58,7 @@ func TestABMEditor(t *testing.T) {
 		assert.NotContains(abmInstall, "[-]", "gce setup for abm installation should not have any failed stages")
 
 		bmctl := runSSHCmd(t, projectID, "root@cluster1-abm-ws0-001", "bmctl version")
-		assert.Contains(bmctl, "bmctl version: 1.14.0", "bmctl version should be 1.14.0")
+		assert.Contains(bmctl, fmt.Sprintf("bmctl version: %s", abmVersion), fmt.Sprintf("bmctl version should be %s", abmVersion))
 
 		docker := runSSHCmd(t, projectID, "root@cluster1-abm-ws0-001", "docker version")
 		dockerExpectedOP := []string{"Client: Docker Engine", "Server: Docker Engine", "API version", "Version", "linux/amd64"}


### PR DESCRIPTION
#### Description
- Parameterize ABM version to a single `abm_version` variable rather than hard coded
- Set default `abm_version` to 1.14.1
- Updates the test to use `abm_version` instead of using hard coded
