### PR TITLE
improvement: use variables for ABM version

### DIFF
--- a/anthos-bm-gcp-bash/install_admin_cluster.sh
+++ b/anthos-bm-gcp-bash/install_admin_cluster.sh
@@ -28,17 +28,17 @@ fi
 if [[ -z "${ADMIN_CLUSTER_NAME}" ]]; then
   printf "🚨 Environment variable ADMIN_CLUSTER_NAME not set.\n"
   while true; do
-    read -rp "💡 Should the script continue with the default name - 'abm-admin-cluster'? " yn
+    read -rp "💡 Should the script continue with the default name - 'abm-admin-cluster'? (Use 'Y' or 'y for Yes and 'N' or 'n' for No)" yn
     case $yn in
         [Yy]* ) ADMIN_CLUSTER_NAME="abm-admin-cluster"; break;;
         [Nn]* ) exit 1;;
-        * ) echo "Please answer yes or no.";;
+        * ) echo "Please answer 'Y' or 'y for Yes and 'N' or 'n' for No.";;
     esac
   done
 fi
 
 if [[ -z "${BMCTL_VERSION}" ]]; then
-  printf "🚨 Environment variable BMCTL_VERSION not set. Set it to the Anthos bare metal version you intend to use."
+  printf "🚨 Environment variable BMCTL_VERSION is not set. Set it to the Anthos bare metal version you intend to use."
   exit 1
 fi
 

--- a/anthos-bm-gcp-bash/install_hybrid_cluster.sh
+++ b/anthos-bm-gcp-bash/install_hybrid_cluster.sh
@@ -16,17 +16,17 @@
 set -euo pipefail
 
 if [[ -z "${PROJECT_ID}" ]]; then
-  printf "🚨 Environment variable PROJECT_ID not set. Set it to the Google Cloud Project you intend to use."
+  printf "🚨 Environment variable PROJECT_ID is not set. Set it to the Google Cloud Project you intend to use."
   exit 1
 fi
 
 if [[ -z "${ZONE}" ]]; then
-  printf "🚨 Environment variable ZONE not set. Set it to the Google Cloud Zone where the resources must be created."
+  printf "🚨 Environment variable ZONE is not set. Set it to the Google Cloud Zone where the resources must be created."
   exit 1
 fi
 
 if [[ -z "${ADMIN_CLUSTER_NAME}" ]]; then
-  printf "🚨 Environment variable ADMIN_CLUSTER_NAME not set.\n"
+  printf "🚨 Environment variable ADMIN_CLUSTER_NAME is not set.\n"
   while true; do
     read -rp "💡 Should the script continue with the default name - 'abm-admin-cluster'? " yn
     case $yn in

--- a/anthos-bm-gcp-bash/install_hybrid_cluster.sh
+++ b/anthos-bm-gcp-bash/install_hybrid_cluster.sh
@@ -25,12 +25,12 @@ if [[ -z "${ZONE}" ]]; then
   exit 1
 fi
 
-if [[ -z "${ADMIN_CLUSTER_NAME}" ]]; then
-  printf "🚨 Environment variable ADMIN_CLUSTER_NAME is not set.\n"
+if [[ -z "${CLUSTER_NAME}" ]]; then
+  printf "🚨 Environment variable CLUSTER_NAME is not set.\n"
   while true; do
-    read -rp "💡 Should the script continue with the default name - 'abm-admin-cluster'? " yn
+    read -rp "💡 Should the script continue with the default name - 'abm-cluster'? " yn
     case $yn in
-        [Yy]* ) ADMIN_CLUSTER_NAME="abm-admin-cluster"; break;;
+        [Yy]* ) CLUSTER_NAME="abm-cluster"; break;;
         [Nn]* ) exit 1;;
         * ) echo "Please answer yes or no.";;
     esac
@@ -42,7 +42,7 @@ if [[ -z "${BMCTL_VERSION}" ]]; then
   exit 1
 fi
 
-printf "\n✅ Using Project [%s], Zone [%s], Cluster name [%s] and Anthos bare metal version [%s].\n\n" "$PROJECT_ID" "$ZONE" "$ADMIN_CLUSTER_NAME" "$BMCTL_VERSION"
+printf "\n✅ Using Project [%s], Zone [%s], Cluster name [%s] and Anthos bare metal version [%s].\n\n" "$PROJECT_ID" "$ZONE" "$CLUSTER_NAME" "$BMCTL_VERSION"
 
 # create the GCP Service Account to be used by Anthos on bare metal
 printf "🔄 Creating Service Account and Service Account key...\n"
@@ -147,7 +147,7 @@ do
       --enable-nested-virtualization \
       --scopes cloud-platform \
       --machine-type "$MACHINE_TYPE" \
-      --metadata "cluster_id=${ADMIN_CLUSTER_NAME},bmctl_version=${BMCTL_VERSION}"
+      --metadata "cluster_id=${CLUSTER_NAME},bmctl_version=${BMCTL_VERSION}"
     IP=$(gcloud compute instances describe "$vm" --zone "${ZONE}" \
          --format='get(networkInterfaces[0].networkIP)')
     IPs+=("$IP")
@@ -249,12 +249,12 @@ printf "🔄 Installing Anthos on bare metal...\n"
 gcloud compute ssh root@$VM_WS --zone "${ZONE}" <<EOF
 set -x
 export PROJECT_ID=$(gcloud config get-value project)
-ADMIN_CLUSTER_NAME=\$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster_id -H "Metadata-Flavor: Google")
+CLUSTER_NAME=\$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster_id -H "Metadata-Flavor: Google")
 BMCTL_VERSION=\$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/bmctl_version -H "Metadata-Flavor: Google")
-export ADMIN_CLUSTER_NAME
+export CLUSTER_NAME
 export BMCTL_VERSION
-bmctl create config -c \$ADMIN_CLUSTER_NAME
-cat > bmctl-workspace/\$ADMIN_CLUSTER_NAME/\$ADMIN_CLUSTER_NAME.yaml << EOB
+bmctl create config -c \$CLUSTER_NAME
+cat > bmctl-workspace/\$CLUSTER_NAME/\$CLUSTER_NAME.yaml << EOB
 ---
 gcrKeyPath: /root/bm-gcr.json
 sshPrivateKeyPath: /root/.ssh/id_rsa
@@ -265,13 +265,13 @@ cloudOperationsServiceAccountKeyPath: /root/bm-gcr.json
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: cluster-\$ADMIN_CLUSTER_NAME
+  name: cluster-\$CLUSTER_NAME
 ---
 apiVersion: baremetal.cluster.gke.io/v1
 kind: Cluster
 metadata:
-  name: \$ADMIN_CLUSTER_NAME
-  namespace: cluster-\$ADMIN_CLUSTER_NAME
+  name: \$CLUSTER_NAME
+  namespace: cluster-\$CLUSTER_NAME
 spec:
   type: hybrid
   anthosBareMetalVersion: \$BMCTL_VERSION
@@ -279,7 +279,7 @@ spec:
     projectID: \$PROJECT_ID
   controlPlane:
     nodePoolSpec:
-      clusterName: \$ADMIN_CLUSTER_NAME
+      clusterName: \$CLUSTER_NAME
       nodes:
       - address: 10.200.0.3
       - address: 10.200.0.4
@@ -322,15 +322,15 @@ apiVersion: baremetal.cluster.gke.io/v1
 kind: NodePool
 metadata:
   name: node-pool-1
-  namespace: cluster-\$ADMIN_CLUSTER_NAME
+  namespace: cluster-\$CLUSTER_NAME
 spec:
-  clusterName: \$ADMIN_CLUSTER_NAME
+  clusterName: \$CLUSTER_NAME
   nodes:
   - address: 10.200.0.6
   - address: 10.200.0.7
 EOB
 
-bmctl create cluster -c \$ADMIN_CLUSTER_NAME
+bmctl create cluster -c \$CLUSTER_NAME
 EOF
 # [END anthos_bm_gcp_bash_hybrid_install_abm]
 printf "✅ Installation complete. Please check the logs for any errors!!!\n\n"

--- a/anthos-bm-gcp-bash/install_hybrid_cluster.sh
+++ b/anthos-bm-gcp-bash/install_hybrid_cluster.sh
@@ -15,7 +15,34 @@
 
 set -euo pipefail
 
-printf "✅ Using Project [%s] and Zone [%s].\n\n" "$PROJECT_ID" "$ZONE"
+if [[ -z "${PROJECT_ID}" ]]; then
+  printf "🚨 Environment variable PROJECT_ID not set. Set it to the Google Cloud Project you intend to use."
+  exit 1
+fi
+
+if [[ -z "${ZONE}" ]]; then
+  printf "🚨 Environment variable ZONE not set. Set it to the Google Cloud Zone where the resources must be created."
+  exit 1
+fi
+
+if [[ -z "${ADMIN_CLUSTER_NAME}" ]]; then
+  printf "🚨 Environment variable ADMIN_CLUSTER_NAME not set.\n"
+  while true; do
+    read -rp "💡 Should the script continue with the default name - 'abm-admin-cluster'? " yn
+    case $yn in
+        [Yy]* ) ADMIN_CLUSTER_NAME="abm-admin-cluster"; break;;
+        [Nn]* ) exit 1;;
+        * ) echo "Please answer yes or no.";;
+    esac
+  done
+fi
+
+if [[ -z "${BMCTL_VERSION}" ]]; then
+  printf "🚨 Environment variable BMCTL_VERSION not set. Set it to the Anthos bare metal version you intend to use."
+  exit 1
+fi
+
+printf "\n✅ Using Project [%s], Zone [%s], Cluster name [%s] and Anthos bare metal version [%s].\n\n" "$PROJECT_ID" "$ZONE" "$ADMIN_CLUSTER_NAME" "$BMCTL_VERSION"
 
 # create the GCP Service Account to be used by Anthos on bare metal
 printf "🔄 Creating Service Account and Service Account key...\n"
@@ -119,7 +146,8 @@ do
       --min-cpu-platform "Intel Haswell" \
       --enable-nested-virtualization \
       --scopes cloud-platform \
-      --machine-type "$MACHINE_TYPE"
+      --machine-type "$MACHINE_TYPE" \
+      --metadata "cluster_id=${ADMIN_CLUSTER_NAME},bmctl_version=${BMCTL_VERSION}"
     IP=$(gcloud compute instances describe "$vm" --zone "${ZONE}" \
          --format='get(networkInterfaces[0].networkIP)')
     IPs+=("$IP")
@@ -176,6 +204,8 @@ gcloud compute ssh root@$VM_WS --zone "${ZONE}" << EOF
 set -x
 
 export PROJECT_ID=\$(gcloud config get-value project)
+BMCTL_VERSION=\$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/bmctl_version -H "Metadata-Flavor: Google")
+export BMCTL_VERSION
 
 gcloud iam service-accounts keys create bm-gcr.json \
   --iam-account=baremetal-gcr@\${PROJECT_ID}.iam.gserviceaccount.com
@@ -185,7 +215,7 @@ curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s ht
 chmod +x kubectl
 mv kubectl /usr/local/sbin/
 mkdir baremetal && cd baremetal
-gsutil cp gs://anthos-baremetal-release/bmctl/1.14.0/linux-amd64/bmctl .
+gsutil cp gs://anthos-baremetal-release/bmctl/$BMCTL_VERSION/linux-amd64/bmctl .
 chmod a+x bmctl
 mv bmctl /usr/local/sbin/
 
@@ -219,9 +249,12 @@ printf "🔄 Installing Anthos on bare metal...\n"
 gcloud compute ssh root@$VM_WS --zone "${ZONE}" <<EOF
 set -x
 export PROJECT_ID=$(gcloud config get-value project)
-export clusterid=cluster-1
-bmctl create config -c \$clusterid
-cat > bmctl-workspace/\$clusterid/\$clusterid.yaml << EOB
+ADMIN_CLUSTER_NAME=\$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster_id -H "Metadata-Flavor: Google")
+BMCTL_VERSION=\$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/bmctl_version -H "Metadata-Flavor: Google")
+export ADMIN_CLUSTER_NAME
+export BMCTL_VERSION
+bmctl create config -c \$ADMIN_CLUSTER_NAME
+cat > bmctl-workspace/\$ADMIN_CLUSTER_NAME/\$ADMIN_CLUSTER_NAME.yaml << EOB
 ---
 gcrKeyPath: /root/bm-gcr.json
 sshPrivateKeyPath: /root/.ssh/id_rsa
@@ -232,21 +265,21 @@ cloudOperationsServiceAccountKeyPath: /root/bm-gcr.json
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: cluster-\$clusterid
+  name: cluster-\$ADMIN_CLUSTER_NAME
 ---
 apiVersion: baremetal.cluster.gke.io/v1
 kind: Cluster
 metadata:
-  name: \$clusterid
-  namespace: cluster-\$clusterid
+  name: \$ADMIN_CLUSTER_NAME
+  namespace: cluster-\$ADMIN_CLUSTER_NAME
 spec:
   type: hybrid
-  anthosBareMetalVersion: 1.13.1
+  anthosBareMetalVersion: \$BMCTL_VERSION
   gkeConnect:
     projectID: \$PROJECT_ID
   controlPlane:
     nodePoolSpec:
-      clusterName: \$clusterid
+      clusterName: \$ADMIN_CLUSTER_NAME
       nodes:
       - address: 10.200.0.3
       - address: 10.200.0.4
@@ -289,15 +322,15 @@ apiVersion: baremetal.cluster.gke.io/v1
 kind: NodePool
 metadata:
   name: node-pool-1
-  namespace: cluster-\$clusterid
+  namespace: cluster-\$ADMIN_CLUSTER_NAME
 spec:
-  clusterName: \$clusterid
+  clusterName: \$ADMIN_CLUSTER_NAME
   nodes:
   - address: 10.200.0.6
   - address: 10.200.0.7
 EOB
 
-bmctl create cluster -c \$clusterid
+bmctl create cluster -c \$ADMIN_CLUSTER_NAME
 EOF
 # [END anthos_bm_gcp_bash_hybrid_install_abm]
 printf "✅ Installation complete. Please check the logs for any errors!!!\n\n"


### PR DESCRIPTION
### Fixes [b/267926089](http://b/267926089)

#### Description
- The step to download the bmctl CLI has the ABM version hardcoded
- The step to install the cluster in [the doc (that uses this script)](https://cloud.google.com/anthos/clusters/docs/bare-metal/latest/try/gce-vms#deploy_an_hybrid_cluster) the version is taken from the devsite variable `current_patch`.
- As a result when this doc is released for the new versions of ABM we have to make sure we update this script also to reflect that change. 
- This will impact previous versions of the documentation
- Thus, we extract the ABM version as a variable in this PR
- We then will update the docs to add an additional step to mention the ABM version at the beginning. We will set `current_patch` as the default version on different releases of the documentation
- You can see [this doc](https://cloud.google.com/anthos/clusters/docs/bare-metal/latest/try/admin-user-gce-vms) as an example of this approach which uses the other script in this repo [install_admin_cluster.sh](https://github.com/GoogleCloudPlatform/anthos-samples/blob/main/anthos-bm-gcp-bash/install_admin_cluster.sh)

#### Change summary
- Add a new input variable and update all places where ABM version is used
- Add also an additional variable for cluster name as a nice to have

#### Related PRs/Issues
- N/A


