### PR TITLE
chore: add trusted-contribution

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -1,0 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+annotations:
+  - type: comment
+    text: "/gcbrun"
+trustedContributors:
+  - release-please[bot]
+  - renovate[bot]
+  - forking-renovate[bot]
+  - apeabody


### PR DESCRIPTION
#### Description
- add `trusted-contribution.yml` for use with https://github.com/googleapis/repo-automation-bots
- Automatically adds `/gcbrun` to PRs from listed Contributors

