### PR TITLE
chore: Fix Renovate in trusted-contribution

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -18,6 +18,7 @@ annotations:
 trustedContributors:
   - release-please[bot]
   - renovate[bot]
+  - renovate-bot
   - forking-renovate[bot]
   - dependabot[bot]
   - apeabody


### PR DESCRIPTION
This PR adds another entry for Renovate called `renovate-bot` in the trusted-contribution. This is to make sure to catch any instances of the Renovate bot opening PRs against this repository, which are currently not all caught (for example: https://github.com/GoogleCloudPlatform/anthos-samples/pull/590).