### PR TITLE
chore: update install_admin_cluster.sh

### DIFF
--- a/anthos-bm-gcp-bash/install_admin_cluster.sh
+++ b/anthos-bm-gcp-bash/install_admin_cluster.sh
@@ -286,7 +286,7 @@ spec:
       - 192.168.0.0/16
     services:
       cidrBlocks:
-      - 172.26.232.0/24
+      - 10.96.0.0/20
   loadBalancer:
     mode: bundled
     ports:


### PR DESCRIPTION
Change the service CIDR to 10.96.0.0/20, which is the default used in the docs and UI.

### Fixes ISSUE_NO_HERE
- If you still haven't done yet, then please do create an issue in the repository before opening this PR

#### Description
- Brief description of the issue/purpose of this PR
- Include environment _(e.g: Linux/Ubuntu running terraform v14.10 etc)_ if relavant

#### Change summary
- List of changes done in this PR

#### Related PRs/Issues
- List any related PRs and Issues


