### PR TITLE
Add validating webhook configs to create_snapshot.py

### DIFF
--- a/troubleshooting/create_snapshot.py
+++ b/troubleshooting/create_snapshot.py
@@ -61,6 +61,8 @@ KUBECTL_GLOBAL_CMDS = [
     'kubectl describe clusterrolebindings {kubeconfig_arg} --request-timeout {timeout}',      # noqa: E501
     'kubectl describe crd {kubeconfig_arg} --request-timeout {timeout}',
     'kubectl describe nodes {kubeconfig_arg} --request-timeout {timeout}',
+    'kubectl get validatingwebhookconfigurations -o wide {kubeconfig_arg} --request-timeout {timeout}`,
+    'kubectl get validatingwebhookconfigurations -o yaml {kubeconfig_arg} --request-timeout {timeout}`,
 ]
 
 KUBECTL_PER_NS_CMDS = [


### PR DESCRIPTION
Many Anthos products (Policy Controller, for example) use ValidatingWebhookConfigurations.  As webhooks are called in requests to the API server, they are also a common source of problems on the cluster.  Adding them to this script will better enable engineers to understand the state of the cluster.
