### PR TITLE
feat(create_snapshot.py): Adding debug information for mutating webhook configs

### DIFF
--- a/troubleshooting/create_snapshot.py
+++ b/troubleshooting/create_snapshot.py
@@ -63,6 +63,8 @@ KUBECTL_GLOBAL_CMDS = [
     'kubectl describe nodes {kubeconfig_arg} --request-timeout {timeout}',
     'kubectl get validatingwebhookconfigurations -o wide {kubeconfig_arg} --request-timeout {timeout}',  # noqa: E501
     'kubectl get validatingwebhookconfigurations -o yaml {kubeconfig_arg} --request-timeout {timeout}',  # noqa: E501
+    'kubectl get mutatingwebhookconfigurations -o wide {kubeconfig_arg} --request-timeout {timeout}',  # noqa: E501
+    'kubectl get mutatingwebhookconfigurations -o yaml {kubeconfig_arg} --request-timeout {timeout}',  # noqa: E501
 ]
 
 KUBECTL_PER_NS_CMDS = [


### PR DESCRIPTION
#### Description
Many Anthos products (Policy Controller, for example) use MutatingWebhookConfigurations. As webhooks are called in requests to the API server, they are also a common source of problems on the cluster. Adding them to this script will better enable engineers to understand the state of the cluster.

#### Change summary
- Adding two calls which produce debug information on MutatingWebhookConfigurations

#### Related PRs/Issues
- Similar PR: https://github.com/GoogleCloudPlatform/anthos-samples/pull/596


