### PR TITLE
improvement: update nettest manifests to version v0.3.7-gke.9__linux_amd64

### DIFF
--- a/anthos-bm-utils/abm-nettest/nettest.yaml
+++ b/anthos-bm-utils/abm-nettest/nettest.yaml
@@ -33,12 +33,16 @@ spec:
     spec:
       containers:
       - name: echoserver
-        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.3__linux_amd64
+        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.7-gke.9__linux_amd64
         imagePullPolicy: IfNotPresent
+        args: ["--port=9222"]
         ports:
-        - containerPort: 8080
+        - containerPort: 9222
       tolerations:
         - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
 ---
@@ -59,12 +63,16 @@ spec:
       hostNetwork: true
       containers:
       - name: echoserver
-        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.3__linux_amd64
+        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.7-gke.9__linux_amd64
         imagePullPolicy: IfNotPresent
+        args: ["--port=9222"]
         ports:
-        - containerPort: 8080
+        - containerPort: 9222
       tolerations:
         - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
 ---
@@ -76,7 +84,7 @@ metadata:
 spec:
   ports:
   - port: 80
-    targetPort: 8080
+    targetPort: 9222
     protocol: TCP
   selector:
     run: echoserver-non-hostnetwork
@@ -89,7 +97,7 @@ metadata:
 spec:
   ports:
   - port: 80
-    targetPort: 8080
+    targetPort: 9222
     protocol: TCP
   selector:
     run: echoserver-hostnetwork
@@ -251,7 +259,7 @@ metadata:
 spec:
   containers:
   - name: nettest
-    image: gcr.io/anthos-baremetal-release/nettest:v0.3.3__linux_amd64
+    image: gcr.io/anthos-baremetal-release/nettest:v0.3.7-gke.9__linux_amd64
     imagePullPolicy: IfNotPresent
     command: ["/nettest"]
     args: ["-v=2", "-alsologtostderr", "-engine_config=/cfg/engine.yaml"]

--- a/anthos-bm-utils/abm-nettest/nettest_rhel.yaml
+++ b/anthos-bm-utils/abm-nettest/nettest_rhel.yaml
@@ -33,14 +33,21 @@ spec:
     spec:
       containers:
       - name: echoserver
-        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.3__linux_amd64
+        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.7-gke.9__linux_amd64
         imagePullPolicy: IfNotPresent
+        args: ["--port=9222"]
         ports:
-        - containerPort: 8080
+        - containerPort: 9222
       tolerations:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -59,14 +66,21 @@ spec:
       hostNetwork: true
       containers:
       - name: echoserver
-        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.3__linux_amd64
+        image: gcr.io/anthos-baremetal-release/simplehttpserver:v0.3.7-gke.9__linux_amd64
         imagePullPolicy: IfNotPresent
+        args: ["--port=9222"]
         ports:
-        - containerPort: 8080
+        - containerPort: 9222
       tolerations:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
 ---
 apiVersion: v1
 kind: Service
@@ -76,7 +90,7 @@ metadata:
 spec:
   ports:
   - port: 80
-    targetPort: 8080
+    targetPort: 9222
     protocol: TCP
   selector:
     run: echoserver-non-hostnetwork
@@ -89,7 +103,7 @@ metadata:
 spec:
   ports:
   - port: 80
-    targetPort: 8080
+    targetPort: 9222
     protocol: TCP
   selector:
     run: echoserver-hostnetwork
@@ -251,7 +265,7 @@ metadata:
 spec:
   containers:
   - name: nettest
-    image: gcr.io/anthos-baremetal-release/nettest:v0.3.3__linux_amd64
+    image: gcr.io/anthos-baremetal-release/nettest:v0.3.7-gke.9__linux_amd64
     imagePullPolicy: IfNotPresent
     command: ["/nettest"]
     args: ["-v=2", "-alsologtostderr", "-engine_config=/cfg/engine.yaml"]


### PR DESCRIPTION
This version includes logic to create cloudprobers with correct toleration for CP nodes.
The manifest also includes correct toleration for echoserver, while choosing 9222 as a port, to reduce likelihood of port collision with others.

### Fixes #654 

#### Description
- This change enables running nettest on CP nodes as well to check network connectivity CP nodes and other k8s nodes/pods/svcs.


