### PR TITLE
fixes #675:: install_admin_cluster.sh : check SSH access timeout

### DIFF
--- a/anthos-bm-gcp-bash/install_admin_cluster.sh
+++ b/anthos-bm-gcp-bash/install_admin_cluster.sh
@@ -203,7 +203,7 @@ printf "🔄 Checking SSH access to the GCE VMs...\n"
 # [START anthos_bm_gcp_bash_admin_check_ssh]
 for vm in "${VMs[@]}"
 do
-    while ! gcloud compute ssh root@"$vm" --zone "${ZONE}" --command "printf SSH to $vm succeeded"
+    while ! gcloud compute ssh root@"$vm" --zone "${ZONE}" --tunnel-through-iap --command "printf SSH to $vm succeeded"
     do
         printf "Trying to SSH into %s failed. Sleeping for 5 seconds. zzzZZzzZZ" "$vm"
         sleep  5
@@ -219,7 +219,7 @@ printf "🔄 Setting up VxLAN in the GCE VMs...\n"
 i=2 # We start from 10.200.0.2/24
 for vm in "${VMs[@]}"
 do
-gcloud compute ssh root@"$vm" --zone "${ZONE}" << EOF
+gcloud compute ssh root@"$vm" --zone "${ZONE}" --tunnel-through-iap << EOF
     apt-get -qq update > /dev/null
     apt-get -qq install -y jq > /dev/null
     set -x
@@ -242,7 +242,7 @@ printf "✅ Successfully setup VxLAN in the GCE VMs.\n\n"
 # install the necessary tools inside the VMs
 printf "🔄 Setting up admin workstation...\n"
 # [START anthos_bm_gcp_bash_admin_init_vm]
-gcloud compute ssh root@$VM_WS --zone "${ZONE}" << EOF
+gcloud compute ssh root@$VM_WS --zone "${ZONE}" --tunnel-through-iap << EOF
 set -x
 
 export PROJECT_ID=\$(gcloud config get-value project)
@@ -273,7 +273,7 @@ printf "✅ Successfully set up admin workstation.\n\n"
 # to all the other (control-plane and worker) VMs
 printf "🔄 Setting up SSH access from admin workstation to cluster node VMs...\n"
 # [START anthos_bm_gcp_bash_admin_add_ssh_keys]
-gcloud compute ssh root@$VM_WS --zone "${ZONE}" << EOF
+gcloud compute ssh root@$VM_WS --zone "${ZONE}" --tunnel-through-iap << EOF
 set -x
 ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa
 sed 's/ssh-rsa/root:ssh-rsa/' ~/.ssh/id_rsa.pub > ssh-metadata
@@ -291,7 +291,7 @@ then
   # initiate Anthos on bare metal installation from the admin workstation
   printf "🔄 Installing Anthos on bare metal...\n"
   # [START anthos_bm_gcp_bash_admin_install_abm]
-  gcloud compute ssh root@"$VM_WS" --zone "${ZONE}" <<EOF
+  gcloud compute ssh root@"$VM_WS" --zone "${ZONE}" --tunnel-through-iap <<EOF
 set -x
 export PROJECT_ID=\$(gcloud config get-value project)
 ADMIN_CLUSTER_NAME=\$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster_id -H "Metadata-Flavor: Google")


### PR DESCRIPTION

### Fixes 675
"anthos-bm-gcp-bash/install_admin_cluster.sh" : check SSH access timeout #675

#### Description
The cluster provision on GCE VMs fails on check SSH step due to connection timeout and keeps going on in a loop

#### Change summary
Add flag `--tunnel-through-iap` in the gcloud commands

#### Related Doc
https://cloud.google.com/anthos/clusters/docs/bare-metal/latest/try/admin-user-gce-vms

