### PR TITLE
Adding more APIs and role binding to the prerequisite #678

### DIFF
--- a/anthos-bm-gcp-bash/install_admin_cluster.sh
+++ b/anthos-bm-gcp-bash/install_admin_cluster.sh
@@ -115,6 +115,8 @@ gcloud services enable \
     stackdriver.googleapis.com \
     monitoring.googleapis.com \
     logging.googleapis.com \
+    kubernetesmetadata.googleapis.com  \
+    iam.googleapis.com \
     opsconfigmonitoring.googleapis.com
 # [END anthos_bm_gcp_bash_admin_enable_api]
 printf "✅ Successfully enabled GCP Service APIs.\n\n"
@@ -156,6 +158,12 @@ gcloud projects add-iam-policy-binding "$PROJECT_ID" \
   --member="serviceAccount:baremetal-gcr@$PROJECT_ID.iam.gserviceaccount.com" \
   --role="roles/opsconfigmonitoring.resourceMetadata.writer" \
   --no-user-output-enabled
+
+gcloud projects add-iam-policy-binding PROJECT_ID \
+    --member="serviceAccount:baremetal-gcr@$PROJECT_ID.iam.gserviceaccount.com" \
+    --role="roles/kubernetesmetadata.publisher" \
+    --no-user-output-enabled 
+
 # [END anthos_bm_gcp_bash_admin_add_iam_role]
 printf "✅ Successfully added the requires IAM roles to the Service Account.\n\n"
 


### PR DESCRIPTION
While reproducing a case, I noticed that customers using this public document to create GKE on bare metal are likely to encounter errors due to some missing prerequisites..

Under the list on APIs to be enable we need to include the following :

    iam.googleapis.com 
    kubernetesmetadata.googleapis.com 
Also under the role bindings, we need to include the following :

gcloud projects add-iam-policy-binding PROJECT_ID \
    --member="serviceAccount:baremetal-gcr@$PROJECT_ID.iam.gserviceaccount.com" \
    --role="roles/kubernetesmetadata.publisher"