### PR TITLE
Update AWS/Azure READMEs with instructions for setting `cluster_version` and add missing permission for AWS

### DIFF
--- a/anthos-multi-cloud/AWS/README.md
+++ b/anthos-multi-cloud/AWS/README.md
@@ -79,9 +79,14 @@ gcloud components update
 
 1. Edit the following  values in the **terraform.tfvars** file. You can find the project ID in the GCP console on the left side of the dashboard page. The admin user will be the GCP account email address that can login to the clusters once they are created via the connect gateway.
 
+   Select a **supported GKE version** for your chosen region. To find the supported versions, see [GKE on AWS versioning and support](https://cloud.devsite.corp.google.com/kubernetes-engine/multi-cloud/docs/aws/reference/versioning#version_lifespans).
+
    ```bash
    gcp_project_id = "project-id"
    admin_user = "example@example.com"
+   
+   cluster_version = "supported_gke_version"
+   # supported versions at https://cloud.devsite.corp.google.com/kubernetes-engine/multi-cloud/docs/aws/reference/versioning#version_lifespans
    ```
 
 1. Initialize and create terraform plan.

--- a/anthos-multi-cloud/AWS/modules/iam/main.tf
+++ b/anthos-multi-cloud/AWS/modules/iam/main.tf
@@ -106,6 +106,7 @@ data "aws_iam_policy_document" "api_policy_document" {
       "elasticloadbalancing:RemoveTags",
       "iam:AWSServiceName",
       "iam:CreateServiceLinkedRole",
+      "iam:GetInstanceProfile",
       "iam:PassRole",
     ]
     resources = ["*"]

--- a/anthos-multi-cloud/AWS/modules/iam_scope_down/main.tf
+++ b/anthos-multi-cloud/AWS/modules/iam_scope_down/main.tf
@@ -81,6 +81,15 @@ data "aws_iam_policy_document" "api_iam_policy_document" {
       values   = ["autoscaling.amazonaws.com"]
     }
   }
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:GetInstanceProfile",
+    ]
+    resources = [
+      "arn:aws:iam::*:instance-profile/*",
+    ]
+  }
   // Allow passing IAM roles to EC2.
   statement {
     effect = "Allow"

--- a/anthos-multi-cloud/AWS/terraform.tfvars
+++ b/anthos-multi-cloud/AWS/terraform.tfvars
@@ -7,7 +7,10 @@ https://cloud.google.com/anthos/clusters/docs/multi-cloud/aws/reference/supporte
 */
 node_pool_instance_type     = "t3.medium"
 control_plane_instance_type = "t3.medium"
-cluster_version             = "1.25.5-gke.2000"
+/* supported versions
+https://cloud.google.com/anthos/clusters/docs/multi-cloud/aws/reference/supported-versions
+*/
+cluster_version = "1.29.4-gke.200"
 /*
 Use 'gcloud container aws get-server-config --location [gcp-region]' to see Availability --
 https://cloud.google.com/anthos/clusters/docs/multi-cloud/aws/reference/supported-regions

--- a/anthos-multi-cloud/Azure/README.md
+++ b/anthos-multi-cloud/Azure/README.md
@@ -92,9 +92,14 @@ After the cluster has been installed it will show up in the [Kubernetes Engine p
 
 1. Edit the following values in the **terraform.tfvars** file. The admin user will be the GCP account email address that can login to the clusters once they are created via the connect gateway.
 
+   Select a **supported GKE version** for your chosen region. To find the supported versions, see [GKE on AWS versioning and support](https://cloud.devsite.corp.google.com/kubernetes-engine/multi-cloud/docs/aws/reference/versioning#version_lifespans).
+
   ```bash
    gcp_project_id = "xxx-xxx-xxx"
    admin_user = "example@example.com"
+
+   cluster_version = "supported_gke_version"
+   # supported versions at https://cloud.devsite.corp.google.com/kubernetes-engine/multi-cloud/docs/aws/reference/versioning#version_lifespans
    ```
 
 1. Initialize and create terraform plan.

--- a/anthos-multi-cloud/Azure/terraform.tfvars
+++ b/anthos-multi-cloud/Azure/terraform.tfvars
@@ -7,7 +7,10 @@ https://cloud.google.com/anthos/clusters/docs/multi-cloud/azure/reference/suppor
 */
 control_plane_instance_type = "Standard_DS2_v2"
 node_pool_instance_type     = "Standard_DS2_v2"
-cluster_version             = "1.25.5-gke.2000"
+/* supported versions
+https://cloud.google.com/anthos/clusters/docs/multi-cloud/aws/reference/supported-versions
+*/
+cluster_version = "1.29.4-gke.200"
 /*
 Use 'gcloud container aws get-server-config --location [gcp-region]' to see K8s versions/ region availability --
 https://cloud.google.com/anthos/clusters/docs/multi-cloud/azure/reference/supported-regions


### PR DESCRIPTION
- Update AWS/Azure READMEs with instructions for setting `cluster_version` with link to supported versions. 
- Add missing permission `iam:GetInstanceProfile` for AWS

### Fixes #682 
- If you still haven't done yet, then please do create an issue in the repository before opening this PR

