### PR TITLE
fix(CI): updates to restore CI lint and integration tests

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,47 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: This file was taken from:
+# https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/blob/master/infra/terraform/test-org/org/locals.tf
+
+name: 'lint'
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: 'lint'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'actions/checkout@v4'
+      - id: variables
+        run: |
+          MAKEFILE=$(find . -name Makefile -print -quit)
+          if [ -z "$MAKEFILE" ]; then
+            echo dev-tools=gcr.io/cloud-foundation-cicd/cft/developer-tools:1 >> "$GITHUB_OUTPUT"
+          else
+            VERSION=$(grep "DOCKER_TAG_VERSION_DEVELOPER_TOOLS := " $MAKEFILE | cut -d\  -f3)
+            IMAGE=$(grep "DOCKER_IMAGE_DEVELOPER_TOOLS := " $MAKEFILE | cut -d\  -f3)
+            REGISTRY=$(grep "REGISTRY_URL := " $MAKEFILE | cut -d\  -f3)
+            echo dev-tools=${REGISTRY}/${IMAGE}:${VERSION} >> "$GITHUB_OUTPUT"
+          fi
+      - run: docker run --rm -v ${{ github.workspace }}:/workspace ${{ steps.variables.outputs.dev-tools }} /usr/local/bin/test_lint.sh

--- a/anthos-attached-clusters/kind/README.md
+++ b/anthos-attached-clusters/kind/README.md
@@ -43,13 +43,10 @@ The other examples and module limit dependancies to terraform core providers, bu
            --membership=${CLUSTER} \
            --role=${ROLE} \
            --users=${PRINCIPAL}
-           
-    gcloud container fleet  memberships get-credentials ${CLUSTER}  --project ${PROJECT} 
-    
+
+    gcloud container fleet  memberships get-credentials ${CLUSTER}  --project ${PROJECT}
+
     kubectl get ns
 
     ```
     This will allow you to access the cluster using kubectl as you would other GKE Enterprise clusters, regardless of location (ie in GCP, other clouds, or on prem).
-
-
-

--- a/anthos-bm-apigee/docs/variables.md
+++ b/anthos-bm-apigee/docs/variables.md
@@ -22,7 +22,7 @@ terraform-docs markdown table \
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= v0.15.5, < 1.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= v0.15.5, < 1.4 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.68.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 3.68.0 |
 

--- a/anthos-bm-apigee/versions.tf
+++ b/anthos-bm-apigee/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= v0.15.5, < 1.2" # this line should not change during a release
+  required_version = ">= v0.15.5, < 1.4" # this line should not change during a release
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/anthos-bm-gcp-bash/install_admin_cluster.sh
+++ b/anthos-bm-gcp-bash/install_admin_cluster.sh
@@ -163,7 +163,7 @@ gcloud projects add-iam-policy-binding "$PROJECT_ID" \
 gcloud projects add-iam-policy-binding "$PROJECT_ID" \
     --member="serviceAccount:baremetal-gcr@$PROJECT_ID.iam.gserviceaccount.com" \
     --role="roles/kubernetesmetadata.publisher" \
-    --no-user-output-enabled 
+    --no-user-output-enabled
 
 gcloud projects add-iam-policy-binding "$PROJECT_ID" \
   --member="serviceAccount:baremetal-gcr@$PROJECT_ID.iam.gserviceaccount.com" \

--- a/anthos-bm-gcp-terraform/docs/variables.md
+++ b/anthos-bm-gcp-terraform/docs/variables.md
@@ -22,7 +22,7 @@ terraform-docs markdown table \
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= v0.15.5, < 1.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= v0.15.5, < 1.4 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.68.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 3.68.0 |
 

--- a/anthos-bm-gcp-terraform/main.tf
+++ b/anthos-bm-gcp-terraform/main.tf
@@ -115,6 +115,33 @@ module "instance_template" {
     module.enable_google_apis_secondary
   ]
   # fetched from previous module to explicitely express dependency
+  project_id           = module.enable_google_apis_secondary.project_id
+  region               = var.region           # --zone=${ZONE}
+  source_image         = var.image            # --image=ubuntu-2004-focal-v20210429
+  source_image_family  = var.image_family     # --image-family=ubuntu-2004-lts
+  source_image_project = var.image_project    # --image-project=ubuntu-os-cloud
+  machine_type         = var.machine_type     # --machine-type $MACHINE_TYPE
+  disk_size_gb         = var.boot_disk_size   # --boot-disk-size 200G
+  disk_type            = var.boot_disk_type   # --boot-disk-type pd-ssd
+  network              = var.network          # --network default
+  tags                 = var.tags             # --tags http-server,https-server
+  min_cpu_platform     = var.min_cpu_platform # --min-cpu-platform "Intel Haswell"
+  can_ip_forward       = true                 # --can-ip-forward
+  # Disable oslogin explicitly since we rely on metadata based ssh-key (issues/70).
+  metadata = {
+    enable-oslogin = "false"
+  }
+  service_account = null
+}
+
+module "instance_template_worker" {
+  source  = "terraform-google-modules/vm/google//modules/instance_template"
+  version = "~> 8.0"
+  depends_on = [
+    module.enable_google_apis_primary,
+    module.enable_google_apis_secondary
+  ]
+  # fetched from previous module to explicitely express dependency
   project_id                   = module.enable_google_apis_secondary.project_id
   region                       = var.region                       # --zone=${ZONE}
   source_image                 = var.image                        # --image=ubuntu-2004-focal-v20210429
@@ -175,7 +202,7 @@ module "worker_vm_hosts" {
   zone              = var.zone
   network           = var.network
   vm_names          = local.worker_vm_names
-  instance_template = module.instance_template.self_link
+  instance_template = module.instance_template_worker.self_link
 }
 
 module "configure_controlplane_lb" {

--- a/anthos-bm-gcp-terraform/terraform.tfvars.sample
+++ b/anthos-bm-gcp-terraform/terraform.tfvars.sample
@@ -15,5 +15,5 @@ instance_count                = {
 #nfs_server                   = true
 #gpu                          = {
 #                                 count = 1,
-#                                 type = "nvidia-tesla-k80"
+#                                 type = "nvidia-tesla-t4"
 #                               }

--- a/anthos-bm-gcp-terraform/variables.tf
+++ b/anthos-bm-gcp-terraform/variables.tf
@@ -41,7 +41,7 @@ variable "region" {
 variable "zone" {
   description = "Zone within the selected Google Cloud Region that is to be used"
   type        = string
-  default     = "us-central1-a"
+  default     = "us-central1-b"
 }
 
 variable "username" {

--- a/anthos-bm-openstack-terraform/resources/abm_cluster_login.sh
+++ b/anthos-bm-openstack-terraform/resources/abm_cluster_login.sh
@@ -64,7 +64,7 @@ metadata:
 type: kubernetes.io/service-account-token
 __EOF__
 
-until [[ $(kubectl get -o=jsonpath="{.data.token}" "secret/${SECRET_NAME}") ]]; do 
+until [[ $(kubectl get -o=jsonpath="{.data.token}" "secret/${SECRET_NAME}") ]]; do
   echo "waiting for token..." >&2;
   sleep 1;
 done

--- a/anthos-bm-openstack-terraform/resources/abm_init_host.sh
+++ b/anthos-bm-openstack-terraform/resources/abm_init_host.sh
@@ -52,7 +52,7 @@ function __setup_kubctl__ () {
 # Install the bmctl CLI for managing the Anthos cluster
 ##############################################################################
 function __setup_bmctl__ () {
-  gsutil cp gs://anthos-baremetal-release/bmctl/${ABM_VERSION}/linux-amd64/bmctl .
+  gsutil cp gs://anthos-baremetal-release/bmctl/"${ABM_VERSION}"/linux-amd64/bmctl .
   chmod a+x bmctl
   sudo mv bmctl /usr/local/sbin/
   __check_exit_status__ $? \

--- a/anthos-bm-openstack-terraform/resources/abm_setup_gcp.sh
+++ b/anthos-bm-openstack-terraform/resources/abm_setup_gcp.sh
@@ -20,9 +20,8 @@
 # Download the service account key in order to configure the Anthos cluster
 ##############################################################################
 function __setup_service_account__ () {
-  gcloud iam service-accounts create ${SERVICE_ACCOUNT}
-  gcloud iam service-accounts keys create bm-gcr.json --iam-account="${SERVICE_ACCOUNT}"@"${PROJECT_ID}".iam.gserviceaccount.com
-  if [ "$?" -eq 0 ]
+  gcloud iam service-accounts create "${SERVICE_ACCOUNT}"
+  if ! gcloud iam service-accounts keys create bm-gcr.json --iam-account="${SERVICE_ACCOUNT}"@"${PROJECT_ID}".iam.gserviceaccount.com
   then
     echo "[+] Successfully downloaded key for service account [$SERVICE_ACCOUNT]"
   else
@@ -80,31 +79,31 @@ cat << EOM
   - roles/opsconfigmonitoring.resourceMetadata.writer
 ------------------------------------------------------------------------------
 EOM
-gcloud projects add-iam-policy-binding $PROJECT_ID \
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
   --member="serviceAccount:${SERVICE_ACCOUNT}@$PROJECT_ID.iam.gserviceaccount.com" \
   --role="roles/gkehub.connect"
 
-gcloud projects add-iam-policy-binding $PROJECT_ID \
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
   --member="serviceAccount:${SERVICE_ACCOUNT}@$PROJECT_ID.iam.gserviceaccount.com" \
   --role="roles/gkehub.admin"
 
-gcloud projects add-iam-policy-binding $PROJECT_ID \
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
   --member="serviceAccount:${SERVICE_ACCOUNT}@$PROJECT_ID.iam.gserviceaccount.com" \
   --role="roles/logging.logWriter"
 
-gcloud projects add-iam-policy-binding $PROJECT_ID \
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
   --member="serviceAccount:${SERVICE_ACCOUNT}@$PROJECT_ID.iam.gserviceaccount.com" \
   --role="roles/monitoring.metricWriter"
 
-gcloud projects add-iam-policy-binding $PROJECT_ID \
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
   --member="serviceAccount:${SERVICE_ACCOUNT}@$PROJECT_ID.iam.gserviceaccount.com" \
   --role="roles/monitoring.dashboardEditor"
 
-gcloud projects add-iam-policy-binding $PROJECT_ID \
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
   --member="serviceAccount:${SERVICE_ACCOUNT}@$PROJECT_ID.iam.gserviceaccount.com" \
   --role="roles/stackdriver.resourceMetadata.writer"
 
-gcloud projects add-iam-policy-binding $PROJECT_ID \
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
   --member="serviceAccount:${SERVICE_ACCOUNT}@$PROJECT_ID.iam.gserviceaccount.com" \
   --role="roles/opsconfigmonitoring.resourceMetadata.writer"
 

--- a/anthos-bm-openstack-terraform/resources/cloud-config.yaml
+++ b/anthos-bm-openstack-terraform/resources/cloud-config.yaml
@@ -1,3 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #cloud-config
 users:
 - default

--- a/anthos-bm-openstack-terraform/resources/create-certs.sh
+++ b/anthos-bm-openstack-terraform/resources/create-certs.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/anthos-multi-cloud/AWS/README.md
+++ b/anthos-multi-cloud/AWS/README.md
@@ -84,7 +84,7 @@ gcloud components update
    ```bash
    gcp_project_id = "project-id"
    admin_user = "example@example.com"
-   
+
    cluster_version = "supported_gke_version"
    # supported versions at https://cloud.devsite.corp.google.com/kubernetes-engine/multi-cloud/docs/aws/reference/versioning#version_lifespans
    ```

--- a/anthos-onprem-terraform/README.md
+++ b/anthos-onprem-terraform/README.md
@@ -11,17 +11,17 @@ For more information, see the reference documentation for each resource.
 
 #### Anthos clusters on bare metal (ABM)
 
-| Type             | Sample _(by loadbalancer type)_                  | Terraform resources | 
+| Type             | Sample _(by loadbalancer type)_                  | Terraform resources |
 | ---------------- | ----------------------------------------------   | ------------------- |
-| **user** cluster | Bundled [MetalLB](./abm_user_cluster_metallb/)   | [google_gkeonprem_bare_metal_cluster](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/gkeonprem_bare_metal_cluster) </br> [google_gkeonprem_bare_metal_node_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/gkeonprem_bare_metal_node_pool) | 
-| **user** cluster | [ManualLB](./abm_user_cluster_manuallb/)         | [google_gkeonprem_bare_metal_cluster](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/gkeonprem_bare_metal_cluster) </br> [google_gkeonprem_bare_metal_node_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/gkeonprem_bare_metal_node_pool) | 
+| **user** cluster | Bundled [MetalLB](./abm_user_cluster_metallb/)   | [google_gkeonprem_bare_metal_cluster](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/gkeonprem_bare_metal_cluster) </br> [google_gkeonprem_bare_metal_node_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/gkeonprem_bare_metal_node_pool) |
+| **user** cluster | [ManualLB](./abm_user_cluster_manuallb/)         | [google_gkeonprem_bare_metal_cluster](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/gkeonprem_bare_metal_cluster) </br> [google_gkeonprem_bare_metal_node_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/gkeonprem_bare_metal_node_pool) |
 
 ---
 
 #### Anthos clusters on VMware (AVMware)
 
-| Type             | Sample _(by loadbalancer type)_                 | Terraform resources | 
+| Type             | Sample _(by loadbalancer type)_                 | Terraform resources |
 | ---------------- | ----------------------------------------------- | ------------------- |
-| **user** cluster | Bundled [MetalLB](./avmw_user_cluster_metallb/) | [google_gkeonprem_vmware_cluster](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/gkeonprem_vmware_cluster) </br> [google_gkeonprem_vmware_node_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/gkeonprem_vmware_node_pool) | 
+| **user** cluster | Bundled [MetalLB](./avmw_user_cluster_metallb/) | [google_gkeonprem_vmware_cluster](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/gkeonprem_vmware_cluster) </br> [google_gkeonprem_vmware_node_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/gkeonprem_vmware_node_pool) |
 
 ---

--- a/anthos-onprem-terraform/avmw_user_cluster_metallb/README.md
+++ b/anthos-onprem-terraform/avmw_user_cluster_metallb/README.md
@@ -58,13 +58,13 @@ have changed directory to where this samples is:
 
 ### Upgrade the user cluster with terraform
 
-Use the same terraform script to upgrade the user cluster, by simply changing 
-the version to the new version. Note that this script can be used for upgrades 
-only if you had created the user cluster using this script. When you run the 
-script with the updated version, the `terraform.tfstate` created during the 
+Use the same terraform script to upgrade the user cluster, by simply changing
+the version to the new version. Note that this script can be used for upgrades
+only if you had created the user cluster using this script. When you run the
+script with the updated version, the `terraform.tfstate` created during the
 first run of the script is compared to recognize the change.
 
-Before upgrading the user cluster, please make sure the admin cluster has been 
+Before upgrading the user cluster, please make sure the admin cluster has been
 enrolled in the Anthos On-Prem API. Steps for enrolling the admin cluster are
 listed in [public documentation](https://cloud.google.com/anthos/clusters/docs/on-prem/latest/how-to/enroll-cluster#enroll_a_cluster).
 
@@ -80,14 +80,14 @@ gcloud beta container vmware admin-clusters enroll ADMIN_CLUSTER_NAME \
 This `gcloud_update_admin_cluster_platform_controller` module uses the `gcloud`
 command prepare the admin cluster to enable the user cluster upgrade.
 
-- [**`gcloud_update_admin_cluster_platform_controller`**](./main.tf#L53-L65): 
+- [**`gcloud_update_admin_cluster_platform_controller`**](./main.tf#L53-L65):
    This module is used to ensure that the ** platform controller** of the admin cluster
    is on a compatible version. The platform controller contains one or more bundles of
    components that the admin cluster uses to manage user clusters. The bundles are
    version specific, that is, the platform controller must contain a bundle version that
    matches the _Anthos on VMware version of the user cluster_.  Thus, by having this
-   module in the script we ensure that the platform controller in the admin cluster is 
-   always on the correct user cluster version. 
+   module in the script we ensure that the platform controller in the admin cluster is
+   always on the correct user cluster version.
 
 Then, following the steps below to upgrade the user cluster via terraform.
 

--- a/anthos-onprem-terraform/avmw_user_cluster_metallb/main.tf
+++ b/anthos-onprem-terraform/avmw_user_cluster_metallb/main.tf
@@ -48,7 +48,7 @@ resource "google_project_service" "default" {
 }
 
 # This module is used to update the platform controller on your admin cluster. This
-# is a necessary step for the user cluster version update. If the admin cluster is 
+# is a necessary step for the user cluster version update. If the admin cluster is
 # already on the correct version, then this module does not change anything
 module "gcloud_update_admin_cluster_platform_controller" {
   source                = "terraform-google-modules/gcloud/google"

--- a/test/fixtures/abm_gce_gpu/main.tf
+++ b/test/fixtures/abm_gce_gpu/main.tf
@@ -15,9 +15,9 @@
  */
 
 locals {
-  ssh_as_tfadmin_cmd = "gcloud compute ssh tfadmin@cluster1-abm-ws0-001 --project=${var.editor_project_id} --zone=us-central1-a --ssh-flag=\"-T\" -q -- ls"
+  ssh_as_tfadmin_cmd = "gcloud compute ssh tfadmin@cluster1-abm-ws0-001 --project=${var.editor_project_id} --zone=us-central1-b --ssh-flag=\"-T\" -q -- ls"
   install_abm_cmd    = <<EOF
-  gcloud compute ssh tfadmin@cluster1-abm-ws0-001 --project=${var.editor_project_id} --zone=us-central1-a \
+  gcloud compute ssh tfadmin@cluster1-abm-ws0-001 --project=${var.editor_project_id} --zone=us-central1-b \
     --ssh-flag=-T -q -- sudo ./run_initialization_checks.sh
   EOF
 }
@@ -29,6 +29,6 @@ module "anthos_bm_gcp" {
   resources_path   = "../../../anthos-bm-gcp-terraform/resources"
   gpu = {
     count = 1,
-    type  = "nvidia-tesla-k80"
+    type  = "nvidia-tesla-t4"
   }
 }

--- a/test/integration/abm_gce_defaults_on_editor_project/abm_gce_editor_test.go
+++ b/test/integration/abm_gce_defaults_on_editor_project/abm_gce_editor_test.go
@@ -98,6 +98,6 @@ func TestABMEditor(t *testing.T) {
 
 // runSSHCmd runs gcloud ssh command with ssh args and returns output
 func runSSHCmd(t *testing.T, project, user, args string) string {
-	commonArgs := gcloud.WithCommonArgs([]string{"--command", args, "--project", project, "--zone", "us-central1-a", "--ssh-flag=-T", "-q"})
+	commonArgs := gcloud.WithCommonArgs([]string{"--command", args, "--project", project, "--zone", "us-central1-b", "--ssh-flag=-T", "-q"})
 	return gcloud.RunCmd(t, fmt.Sprintf("compute ssh %s", user), commonArgs)
 }

--- a/test/integration/abm_gce_gpu/controls/gcloud.rb
+++ b/test/integration/abm_gce_gpu/controls/gcloud.rb
@@ -43,12 +43,14 @@ control "gcloud" do
       it "should have all the default values" do
         x = 0
         while x < 6
-          expect(data[x]["guestAccelerators"]).to include(
-            {
-              "acceleratorCount" => 1,
-              "acceleratorType" => "https://www.googleapis.com/compute/v1/projects/#{project_id}/zones/us-central1-a/acceleratorTypes/nvidia-tesla-k80"
-            }
-          )
+          if data[x]["name"].match?("cluster1-abm-w[1-2]-001")
+            expect(data[x]["guestAccelerators"]).to include(
+              {
+                "acceleratorCount" => 1,
+                "acceleratorType" => "https://www.googleapis.com/compute/v1/projects/#{project_id}/zones/us-central1-b/acceleratorTypes/nvidia-tesla-t4"
+              }
+            )
+          end
           x = x + 1
         end
       end


### PR DESCRIPTION
#### Description
- Updates to restore Integration test (abm-gce-gpu)
  - Switched to currently available GPU type/location, and allocate only to worker nodes
  - With the new dedicated worker node template, also removed nested virtualization from control plane and admin workstation as not required
- Updates to fix and re-enable (migrated from cloudbuild trigger to GH workflow) Lint tests



