### PR TITLE
chore: migrate renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":semanticCommits"
   ],
   "ignorePaths": [
@@ -9,14 +9,14 @@
     "**/anthos-bm-openstack-terraform/**",
     "**/anthos-bm-edge-deployment/**"
   ],
-  "prConcurrentLimit":5,
-  "stabilityDays":7,
+  "prConcurrentLimit": 5,
+  "minimumReleaseAge": "7 days",
   "labels": ["dependencies"],
-    "vulnerabilityAlerts":{
-     "labels":[
-       "type:security"
-     ],
-     "stabilityDays":0
+  "vulnerabilityAlerts": {
+    "labels": [
+      "type:security"
+    ],
+    "minimumReleaseAge": null
   },
   "schedule": [
     "every 1 months on the first day of the month"
@@ -28,8 +28,9 @@
       "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"]
     }
   ],
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": ["(^|/)Makefile$"],
       "matchStrings": [
         "DOCKER_TAG_VERSION_DEVELOPER_TOOLS := (?<currentValue>.*?)\\n"
@@ -39,6 +40,7 @@
       "depNameTemplate": "cft/developer-tools"
     },
     {
+      "customType": "regex",
       "fileMatch": ["(^|/)build/(int|lint)\\.cloudbuild\\.yaml$"],
       "matchStrings": [
         "  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '(?<currentValue>.*?)'\\n"


### PR DESCRIPTION
### Fixes ISSUE_NO_HERE


#### Description
Update to recommendations from `renovate-config-validator`

```shell
% npx -p renovate renovate-config-validator
Need to install the following packages:
renovate@38.77.8
Ok to proceed? (y) y
 INFO: Validating renovate.json
 WARN: Config migration necessary
       "oldConfig": {
[...]
```
After
```
% npx -p renovate renovate-config-validator   
 INFO: Validating renovate.json
 INFO: Config validated successfully
```
#### Change summary
- Update Renovate config

#### Related PRs/Issues
- List any related PRs and Issues


