### PR TITLE
fix: remove line that enables Cloud Source Repositories API as this is now deprecated

### DIFF
--- a/anthos-bm-edge-deployment/scripts/create-primary-gsa.sh
+++ b/anthos-bm-edge-deployment/scripts/create-primary-gsa.sh
@@ -62,8 +62,7 @@ gcloud services enable --project "${PROJECT_ID}" \
   containerregistry.googleapis.com \
   secretmanager.googleapis.com \
   servicemanagement.googleapis.com \
-  serviceusage.googleapis.com \
-  sourcerepo.googleapis.com
+  serviceusage.googleapis.com
 
 ### Create Keyring for SSH key encryption (future terraform) -- Keyring and
 # keys are used to encrypt/decrypt SSH keys on the provisioning system during


### PR DESCRIPTION
### Fixes #745

#### Description
Service account creation script in the edge deployment scenario enables the Cloud Source Repositories API which are now deprecated.  CSR is not used in the deployment and so this can be removed.

#### Change summary
- Removes command to enable CSR API

#### Related PRs/Issues
- closes #745


