### PR TITLE
fix: update from Ubuntu-2004 to Ubuntu-2204

### DIFF
--- a/anthos-bm-gcp-bash/install_admin_cluster.sh
+++ b/anthos-bm-gcp-bash/install_admin_cluster.sh
@@ -215,7 +215,7 @@ printf "🔄 Creating GCE VMs...\n"
 for vm in "${VMs[@]}"
 do
     gcloud compute instances create "$vm" \
-      --image-family=ubuntu-2004-lts --image-project=ubuntu-os-cloud \
+      --image-family=ubuntu-2204-lts --image-project=ubuntu-os-cloud \
       --zone="${ZONE}" \
       --boot-disk-size 200G \
       --boot-disk-type pd-ssd \


### PR DESCRIPTION
this script errors out because of a missing ubuntu-2004

### Fixes ISSUE_NO_HERE

https://github.com/GoogleCloudPlatform/anthos-samples/issues/813

#### Description
- update operating system version

#### Change summary
update from Ubuntu-2004 to Ubuntu-2204

#### Related PRs/Issues
https://github.com/GoogleCloudPlatform/anthos-samples/issues/813


